### PR TITLE
feat: define membership state schema

### DIFF
--- a/schemas/membership-state.json
+++ b/schemas/membership-state.json
@@ -1,0 +1,58 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/finml-sage/agent-swarm-protocol/schemas/membership-state.json",
+  "title": "Agent Membership State",
+  "description": "Local state schema for an agent's swarm memberships, mute lists, and public key registry. Stored at ~/.swarm/state.json",
+  "type": "object",
+  "required": ["schema_version", "agent_id", "swarms", "muted_swarms", "muted_agents", "public_keys"],
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "pattern": "^\\d+\\.\\d+\\.\\d+$",
+      "description": "Version of this state schema for migration support",
+      "const": "1.0.0"
+    },
+    "agent_id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "This agent's unique identifier"
+    },
+    "swarms": {
+      "type": "object",
+      "description": "Map of swarm_id to swarm membership details",
+      "additionalProperties": {
+        "$ref": "types/swarm-membership.json"
+      }
+    },
+    "muted_swarms": {
+      "type": "array",
+      "description": "List of swarm IDs whose messages are silently dropped",
+      "items": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "uniqueItems": true
+    },
+    "muted_agents": {
+      "type": "array",
+      "description": "List of agent IDs whose messages are silently dropped across all swarms",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "uniqueItems": true
+    },
+    "public_keys": {
+      "type": "object",
+      "description": "Registry of known agent public keys for signature verification",
+      "additionalProperties": {
+        "$ref": "types/public-key-entry.json"
+      }
+    },
+    "exported_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO-8601 timestamp when this state was exported (present only in exported files)"
+    }
+  }
+}

--- a/schemas/types/member.json
+++ b/schemas/types/member.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/finml-sage/agent-swarm-protocol/schemas/types/member.json",
+  "title": "Swarm Member",
+  "description": "A member of a swarm with identity, endpoint, and cryptographic key",
+  "type": "object",
+  "required": ["agent_id", "endpoint", "public_key", "joined_at"],
+  "properties": {
+    "agent_id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Unique identifier for this agent"
+    },
+    "endpoint": {
+      "type": "string",
+      "format": "uri",
+      "pattern": "^https://",
+      "description": "HTTPS endpoint for receiving messages"
+    },
+    "public_key": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9+/=]{43,44}$",
+      "description": "Base64-encoded Ed25519 public key (32 bytes, 43-44 chars base64)"
+    },
+    "joined_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO-8601 timestamp when this member joined the swarm"
+    }
+  }
+}

--- a/schemas/types/public-key-entry.json
+++ b/schemas/types/public-key-entry.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/finml-sage/agent-swarm-protocol/schemas/types/public-key-entry.json",
+  "title": "Public Key Entry",
+  "description": "A cached public key for an agent used in signature verification",
+  "type": "object",
+  "required": ["public_key", "fetched_at"],
+  "properties": {
+    "public_key": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9+/=]{43,44}$",
+      "description": "Base64-encoded Ed25519 public key"
+    },
+    "fetched_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO-8601 timestamp when this key was fetched or verified"
+    },
+    "endpoint": {
+      "type": "string",
+      "format": "uri",
+      "pattern": "^https://",
+      "description": "Endpoint where this key was retrieved from"
+    }
+  }
+}

--- a/schemas/types/swarm-membership.json
+++ b/schemas/types/swarm-membership.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/finml-sage/agent-swarm-protocol/schemas/types/swarm-membership.json",
+  "title": "Swarm Membership",
+  "description": "An agent's membership record for a single swarm",
+  "type": "object",
+  "required": ["swarm_id", "name", "master", "members", "joined_at", "settings"],
+  "properties": {
+    "swarm_id": {
+      "type": "string",
+      "format": "uuid",
+      "description": "Unique identifier for this swarm"
+    },
+    "name": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 256,
+      "description": "Human-readable name for the swarm"
+    },
+    "master": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Agent ID of the swarm master who can invite and kick members"
+    },
+    "members": {
+      "type": "array",
+      "description": "List of all swarm members including the master",
+      "items": {
+        "$ref": "member.json"
+      },
+      "minItems": 1
+    },
+    "joined_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO-8601 timestamp when this agent joined the swarm"
+    },
+    "settings": {
+      "$ref": "swarm-settings.json"
+    }
+  }
+}

--- a/schemas/types/swarm-settings.json
+++ b/schemas/types/swarm-settings.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/finml-sage/agent-swarm-protocol/schemas/types/swarm-settings.json",
+  "title": "Swarm Settings",
+  "description": "Configurable settings for swarm behavior",
+  "type": "object",
+  "required": ["allow_member_invite", "require_approval"],
+  "properties": {
+    "allow_member_invite": {
+      "type": "boolean",
+      "default": false,
+      "description": "If true, any member can generate invite tokens; if false, only master can invite"
+    },
+    "require_approval": {
+      "type": "boolean",
+      "default": false,
+      "description": "If true, master must approve join requests; if false, valid invite tokens auto-accept"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Defines the JSON Schema for local agent membership state stored at `~/.swarm/state.json`
- Specifies SwarmMembership object with all required fields (swarm_id, name, master, members[], joined_at, settings)
- Specifies Member object with identity and cryptographic fields (agent_id, endpoint, public_key, joined_at)
- Defines mute lists schema for silently dropping messages from muted swarms or agents
- Defines public key registry schema for caching and verifying agent signatures
- Documents state file location convention and portability for export/import

## Changes

### New Schema Files
- `schemas/membership-state.json` - Main state schema
- `schemas/types/member.json` - Member type definition
- `schemas/types/swarm-membership.json` - Swarm membership type
- `schemas/types/swarm-settings.json` - Swarm settings type
- `schemas/types/public-key-entry.json` - Public key registry entry

### Documentation
- Updated `docs/PROTOCOL.md` section 9 with detailed state specification

## Test plan
- [ ] Validate membership-state.json against JSON Schema draft-2020-12
- [ ] Verify all $ref paths resolve correctly between schema files
- [ ] Confirm PROTOCOL.md section 9 matches schema definitions

Closes #3

---
Generated with [Claude Code](https://claude.ai/code)