### PR TITLE
feat: define swarm operations and request/response payloads

### DIFF
--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1,0 +1,445 @@
+# Swarm Operations Specification
+
+**Protocol Version**: 0.1.0
+
+This document specifies all swarm lifecycle operations for the Agent Swarm Protocol.
+
+## Overview
+
+Swarm operations fall into two categories:
+
+| Category | Operations | Network Required |
+|----------|------------|------------------|
+| Local | Create, Generate Invite | No |
+| Remote | Join, Leave, Kick, Transfer Master | Yes |
+
+## 1. Create Swarm
+
+Creates a new swarm. This is a local operation requiring no network communication.
+
+### Request
+
+None (local operation).
+
+### Response
+
+The operation returns the initial swarm state:
+
+```json
+{
+  "swarm_id": "550e8400-e29b-41d4-a716-446655440000",
+  "name": "my-agent-swarm",
+  "created_at": "2026-02-05T14:30:00.000Z",
+  "master": "agent-001",
+  "members": [
+    {
+      "agent_id": "agent-001",
+      "endpoint": "https://agent-001.example.com",
+      "public_key": "MCowBQYDK2VwAyEA1234567890abcdef...",
+      "joined_at": "2026-02-05T14:30:00.000Z"
+    }
+  ],
+  "settings": {
+    "allow_member_invite": false,
+    "require_approval": false
+  }
+}
+```
+
+### Fields
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| swarm_id | string (UUID) | Yes | Unique identifier for the swarm |
+| name | string | Yes | Human-readable swarm name |
+| created_at | string (ISO 8601) | Yes | Timestamp when swarm was created |
+| master | string | Yes | agent_id of the swarm creator |
+| members | array | Yes | Array of Member objects |
+| settings | object | Yes | Swarm configuration settings |
+
+### Error Responses
+
+| Condition | Error |
+|-----------|-------|
+| Invalid name (empty/too long) | `INVALID_SWARM_NAME` |
+| Storage unavailable | `STORAGE_ERROR` |
+
+## 2. Generate Invite
+
+Generates an invite token for the swarm. This is a local operation.
+
+### Request
+
+```json
+{
+  "swarm_id": "550e8400-e29b-41d4-a716-446655440000",
+  "expires_in_seconds": 86400,
+  "max_uses": 1
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| swarm_id | string (UUID) | Yes | Target swarm |
+| expires_in_seconds | integer | No | Token validity period (default: 86400) |
+| max_uses | integer or null | No | Maximum uses (null = unlimited) |
+
+### Response
+
+```json
+{
+  "invite_url": "swarm://550e8400-e29b-41d4-a716-446655440000@agent-001.example.com?token=eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCJ9...",
+  "token": "eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCJ9...",
+  "expires_at": "2026-02-06T14:30:00.000Z",
+  "max_uses": 1
+}
+```
+
+### JWT Payload Structure
+
+```json
+{
+  "swarm_id": "550e8400-e29b-41d4-a716-446655440000",
+  "master": "agent-001",
+  "endpoint": "https://agent-001.example.com",
+  "expires_at": "2026-02-06T14:30:00.000Z",
+  "max_uses": 1,
+  "iat": 1738766400
+}
+```
+
+### Error Responses
+
+| Condition | Error |
+|-----------|-------|
+| Swarm not found | `SWARM_NOT_FOUND` |
+| Not swarm master | `NOT_AUTHORIZED` |
+| Member invites disabled | `INVITES_DISABLED` |
+
+## 3. Join Swarm
+
+Joins an existing swarm using an invite token. This is a remote operation.
+
+### Endpoint
+
+`POST /swarm/join` on the master's endpoint
+
+### Request
+
+```json
+{
+  "protocol_version": "0.1.0",
+  "message_id": "123e4567-e89b-12d3-a456-426614174000",
+  "timestamp": "2026-02-05T15:00:00.000Z",
+  "type": "system",
+  "action": "join_request",
+  "invite_token": "eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCJ9...",
+  "sender": {
+    "agent_id": "agent-002",
+    "endpoint": "https://agent-002.example.com",
+    "public_key": "MCowBQYDK2VwAyEAabcdef1234567890..."
+  },
+  "signature": "SGVsbG8gV29ybGQhIFRoaXMgaXMgYSB0ZXN0IHNpZ25hdHVyZQ..."
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| protocol_version | string | Yes | Protocol version |
+| message_id | string (UUID) | Yes | Unique request identifier |
+| timestamp | string (ISO 8601) | Yes | Request timestamp |
+| type | string | Yes | Must be "system" |
+| action | string | Yes | Must be "join_request" |
+| invite_token | string | Yes | JWT invite token |
+| sender | object | Yes | Joining agent's info |
+| signature | string | Yes | Ed25519 signature |
+
+### Success Response (200)
+
+```json
+{
+  "status": "accepted",
+  "swarm_id": "550e8400-e29b-41d4-a716-446655440000",
+  "name": "my-agent-swarm",
+  "members": [
+    {
+      "agent_id": "agent-001",
+      "endpoint": "https://agent-001.example.com",
+      "public_key": "MCowBQYDK2VwAyEA1234567890abcdef...",
+      "joined_at": "2026-02-05T14:30:00.000Z"
+    },
+    {
+      "agent_id": "agent-002",
+      "endpoint": "https://agent-002.example.com",
+      "public_key": "MCowBQYDK2VwAyEAabcdef1234567890...",
+      "joined_at": "2026-02-05T15:00:00.000Z"
+    }
+  ],
+  "settings": {
+    "allow_member_invite": false,
+    "require_approval": false
+  }
+}
+```
+
+### Error Responses
+
+| HTTP | Error Code | Condition |
+|------|------------|-----------|
+| 400 | `INVALID_TOKEN` | Token malformed or invalid signature |
+| 400 | `TOKEN_EXPIRED` | Token has expired |
+| 400 | `TOKEN_EXHAUSTED` | Max uses reached |
+| 401 | `INVALID_SIGNATURE` | Request signature invalid |
+| 403 | `APPROVAL_REQUIRED` | Swarm requires approval (pending) |
+| 404 | `SWARM_NOT_FOUND` | Swarm no longer exists |
+| 409 | `ALREADY_MEMBER` | Agent already in swarm |
+
+### Side Effects
+
+Master broadcasts `member_joined` notification to all existing members:
+
+```json
+{
+  "protocol_version": "0.1.0",
+  "message_id": "789e0123-e89b-12d3-a456-426614174000",
+  "timestamp": "2026-02-05T15:00:01.000Z",
+  "sender": {
+    "agent_id": "agent-001",
+    "endpoint": "https://agent-001.example.com"
+  },
+  "recipient": "broadcast",
+  "swarm_id": "550e8400-e29b-41d4-a716-446655440000",
+  "type": "system",
+  "content": "{\"action\":\"member_joined\",\"member\":{\"agent_id\":\"agent-002\",\"endpoint\":\"https://agent-002.example.com\",\"public_key\":\"MCowBQYDK2VwAyEAabcdef1234567890...\",\"joined_at\":\"2026-02-05T15:00:00.000Z\"}}",
+  "signature": "..."
+}
+```
+
+## 4. Leave Swarm
+
+Voluntarily leaves a swarm. The leaving agent broadcasts to all members.
+
+### Endpoint
+
+`POST /swarm/message` on each member's endpoint
+
+### Request (Broadcast)
+
+```json
+{
+  "protocol_version": "0.1.0",
+  "message_id": "456e7890-e89b-12d3-a456-426614174000",
+  "timestamp": "2026-02-05T16:00:00.000Z",
+  "sender": {
+    "agent_id": "agent-002",
+    "endpoint": "https://agent-002.example.com"
+  },
+  "recipient": "broadcast",
+  "swarm_id": "550e8400-e29b-41d4-a716-446655440000",
+  "type": "system",
+  "content": "{\"action\":\"member_left\"}",
+  "signature": "..."
+}
+```
+
+### Success Response (200)
+
+```json
+{
+  "status": "acknowledged",
+  "message_id": "456e7890-e89b-12d3-a456-426614174000"
+}
+```
+
+### Error Responses
+
+| HTTP | Error Code | Condition |
+|------|------------|-----------|
+| 401 | `INVALID_SIGNATURE` | Request signature invalid |
+| 403 | `NOT_MEMBER` | Sender not in swarm |
+| 404 | `SWARM_NOT_FOUND` | Swarm not found |
+
+### Special Case: Master Leaving
+
+If the master leaves without transferring the role:
+1. The swarm is dissolved
+2. All members receive `swarm_dissolved` notification
+
+```json
+{
+  "type": "system",
+  "content": "{\"action\":\"swarm_dissolved\",\"reason\":\"master_left\"}"
+}
+```
+
+## 5. Kick Member
+
+Removes a member from the swarm. Only the master can perform this operation.
+
+### Step 1: Notify Kicked Member
+
+`POST /swarm/message` on the kicked member's endpoint
+
+```json
+{
+  "protocol_version": "0.1.0",
+  "message_id": "abc12345-e89b-12d3-a456-426614174000",
+  "timestamp": "2026-02-05T17:00:00.000Z",
+  "sender": {
+    "agent_id": "agent-001",
+    "endpoint": "https://agent-001.example.com"
+  },
+  "recipient": "agent-003",
+  "swarm_id": "550e8400-e29b-41d4-a716-446655440000",
+  "type": "system",
+  "content": "{\"action\":\"kicked\",\"reason\":\"Inactive for 30 days\"}",
+  "signature": "..."
+}
+```
+
+### Step 2: Broadcast to Remaining Members
+
+```json
+{
+  "protocol_version": "0.1.0",
+  "message_id": "def67890-e89b-12d3-a456-426614174000",
+  "timestamp": "2026-02-05T17:00:01.000Z",
+  "sender": {
+    "agent_id": "agent-001",
+    "endpoint": "https://agent-001.example.com"
+  },
+  "recipient": "broadcast",
+  "swarm_id": "550e8400-e29b-41d4-a716-446655440000",
+  "type": "system",
+  "content": "{\"action\":\"member_kicked\",\"member\":\"agent-003\",\"reason\":\"Inactive for 30 days\"}",
+  "signature": "..."
+}
+```
+
+### Success Response (200)
+
+```json
+{
+  "status": "acknowledged",
+  "message_id": "abc12345-e89b-12d3-a456-426614174000"
+}
+```
+
+### Error Responses
+
+| HTTP | Error Code | Condition |
+|------|------------|-----------|
+| 401 | `INVALID_SIGNATURE` | Request signature invalid |
+| 403 | `NOT_MASTER` | Sender is not swarm master |
+| 404 | `MEMBER_NOT_FOUND` | Target not in swarm |
+| 404 | `SWARM_NOT_FOUND` | Swarm not found |
+
+## 6. Transfer Master Role
+
+Transfers the master role to another member.
+
+### Step 1: Notify New Master
+
+`POST /swarm/message` on the new master's endpoint
+
+```json
+{
+  "protocol_version": "0.1.0",
+  "message_id": "fedcba98-e89b-12d3-a456-426614174000",
+  "timestamp": "2026-02-05T18:00:00.000Z",
+  "sender": {
+    "agent_id": "agent-001",
+    "endpoint": "https://agent-001.example.com"
+  },
+  "recipient": "agent-002",
+  "swarm_id": "550e8400-e29b-41d4-a716-446655440000",
+  "type": "system",
+  "content": "{\"action\":\"master_transfer\"}",
+  "signature": "..."
+}
+```
+
+### Step 2: New Master Accepts
+
+The new master responds with acceptance:
+
+```json
+{
+  "status": "accepted",
+  "message_id": "fedcba98-e89b-12d3-a456-426614174000"
+}
+```
+
+### Step 3: Broadcast to All Members
+
+Old master broadcasts master change:
+
+```json
+{
+  "protocol_version": "0.1.0",
+  "message_id": "01234567-e89b-12d3-a456-426614174000",
+  "timestamp": "2026-02-05T18:00:01.000Z",
+  "sender": {
+    "agent_id": "agent-001",
+    "endpoint": "https://agent-001.example.com"
+  },
+  "recipient": "broadcast",
+  "swarm_id": "550e8400-e29b-41d4-a716-446655440000",
+  "type": "system",
+  "content": "{\"action\":\"master_changed\",\"old_master\":\"agent-001\",\"new_master\":\"agent-002\"}",
+  "signature": "..."
+}
+```
+
+### Success Response (200)
+
+```json
+{
+  "status": "acknowledged",
+  "message_id": "fedcba98-e89b-12d3-a456-426614174000"
+}
+```
+
+### Error Responses
+
+| HTTP | Error Code | Condition |
+|------|------------|-----------|
+| 401 | `INVALID_SIGNATURE` | Request signature invalid |
+| 403 | `NOT_MASTER` | Sender is not current master |
+| 403 | `TRANSFER_DECLINED` | New master declined the role |
+| 404 | `MEMBER_NOT_FOUND` | Target not in swarm |
+| 404 | `SWARM_NOT_FOUND` | Swarm not found |
+
+## Error Response Format
+
+All error responses follow this structure:
+
+```json
+{
+  "error": {
+    "code": "ERROR_CODE",
+    "message": "Human-readable error description",
+    "details": {}
+  }
+}
+```
+
+### Standard Error Codes
+
+| Code | HTTP Status | Description |
+|------|-------------|-------------|
+| `INVALID_TOKEN` | 400 | Token malformed or tampered |
+| `TOKEN_EXPIRED` | 400 | Invite token has expired |
+| `TOKEN_EXHAUSTED` | 400 | Token max uses reached |
+| `INVALID_SIGNATURE` | 401 | Message signature invalid |
+| `NOT_AUTHORIZED` | 403 | Generic authorization failure |
+| `NOT_MASTER` | 403 | Operation requires master role |
+| `NOT_MEMBER` | 403 | Sender not a swarm member |
+| `INVITES_DISABLED` | 403 | Member invites not allowed |
+| `APPROVAL_REQUIRED` | 403 | Join requires master approval |
+| `TRANSFER_DECLINED` | 403 | New master declined transfer |
+| `SWARM_NOT_FOUND` | 404 | Swarm does not exist |
+| `MEMBER_NOT_FOUND` | 404 | Target member not in swarm |
+| `ALREADY_MEMBER` | 409 | Agent already in swarm |
+| `INVALID_SWARM_NAME` | 400 | Swarm name validation failed |
+| `STORAGE_ERROR` | 500 | Persistent storage failure |

--- a/schemas/operations/create.json
+++ b/schemas/operations/create.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/finml-sage/agent-swarm-protocol/schemas/operations/create.json",
+  "title": "Create Swarm Response",
+  "description": "Response schema for the create swarm operation",
+  "type": "object",
+  "required": ["swarm_id", "name", "created_at", "master", "members", "settings"],
+  "properties": {
+    "swarm_id": {
+      "type": "string",
+      "format": "uuid",
+      "description": "Unique identifier for the swarm"
+    },
+    "name": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 128,
+      "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_-]*$",
+      "description": "Human-readable swarm name"
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601 timestamp when swarm was created"
+    },
+    "master": {
+      "type": "string",
+      "minLength": 1,
+      "description": "agent_id of the swarm master"
+    },
+    "members": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "../types/member.json"
+      },
+      "description": "Array of swarm members"
+    },
+    "settings": {
+      "$ref": "../types/swarm-settings.json",
+      "description": "Swarm configuration settings"
+    }
+  }
+}

--- a/schemas/operations/invite.json
+++ b/schemas/operations/invite.json
@@ -1,0 +1,94 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/finml-sage/agent-swarm-protocol/schemas/operations/invite.json",
+  "title": "Generate Invite Schemas",
+  "description": "Request and response schemas for invite generation",
+  "definitions": {
+    "request": {
+      "type": "object",
+      "required": ["swarm_id"],
+      "properties": {
+        "swarm_id": {
+          "type": "string",
+          "format": "uuid",
+          "description": "Target swarm identifier"
+        },
+        "expires_in_seconds": {
+          "type": "integer",
+          "minimum": 60,
+          "maximum": 2592000,
+          "default": 86400,
+          "description": "Token validity period in seconds (default: 24 hours)"
+        },
+        "max_uses": {
+          "type": ["integer", "null"],
+          "minimum": 1,
+          "description": "Maximum number of uses (null for unlimited)"
+        }
+      }
+    },
+    "response": {
+      "type": "object",
+      "required": ["invite_url", "token", "expires_at"],
+      "properties": {
+        "invite_url": {
+          "type": "string",
+          "pattern": "^swarm://[a-f0-9-]+@.+\\?token=.+$",
+          "description": "Full invite URL with embedded token"
+        },
+        "token": {
+          "type": "string",
+          "minLength": 1,
+          "description": "JWT invite token"
+        },
+        "expires_at": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Token expiration timestamp"
+        },
+        "max_uses": {
+          "type": ["integer", "null"],
+          "minimum": 1,
+          "description": "Maximum uses (null if unlimited)"
+        }
+      }
+    },
+    "token_payload": {
+      "type": "object",
+      "required": ["swarm_id", "master", "endpoint", "iat"],
+      "properties": {
+        "swarm_id": {
+          "type": "string",
+          "format": "uuid",
+          "description": "Target swarm identifier"
+        },
+        "master": {
+          "type": "string",
+          "minLength": 1,
+          "description": "agent_id of the swarm master"
+        },
+        "endpoint": {
+          "type": "string",
+          "format": "uri",
+          "pattern": "^https://",
+          "description": "Master's HTTPS endpoint"
+        },
+        "expires_at": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Token expiration timestamp"
+        },
+        "max_uses": {
+          "type": ["integer", "null"],
+          "minimum": 1,
+          "description": "Maximum uses (null if unlimited)"
+        },
+        "iat": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Issued-at Unix timestamp"
+        }
+      }
+    }
+  }
+}

--- a/schemas/operations/join.json
+++ b/schemas/operations/join.json
@@ -1,0 +1,127 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/finml-sage/agent-swarm-protocol/schemas/operations/join.json",
+  "title": "Join Swarm Schemas",
+  "description": "Request and response schemas for joining a swarm",
+  "definitions": {
+    "request": {
+      "type": "object",
+      "required": [
+        "protocol_version",
+        "message_id",
+        "timestamp",
+        "type",
+        "action",
+        "invite_token",
+        "sender",
+        "signature"
+      ],
+      "properties": {
+        "protocol_version": {
+          "type": "string",
+          "pattern": "^\\d+\\.\\d+\\.\\d+$",
+          "description": "Protocol version"
+        },
+        "message_id": {
+          "type": "string",
+          "format": "uuid",
+          "description": "Unique request identifier"
+        },
+        "timestamp": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Request timestamp"
+        },
+        "type": {
+          "type": "string",
+          "const": "system",
+          "description": "Must be system"
+        },
+        "action": {
+          "type": "string",
+          "const": "join_request",
+          "description": "Must be join_request"
+        },
+        "invite_token": {
+          "type": "string",
+          "minLength": 1,
+          "description": "JWT invite token"
+        },
+        "sender": {
+          "type": "object",
+          "required": ["agent_id", "endpoint", "public_key"],
+          "properties": {
+            "agent_id": {
+              "type": "string",
+              "minLength": 1,
+              "description": "Joining agent identifier"
+            },
+            "endpoint": {
+              "type": "string",
+              "format": "uri",
+              "pattern": "^https://",
+              "description": "Joining agent's HTTPS endpoint"
+            },
+            "public_key": {
+              "type": "string",
+              "pattern": "^[A-Za-z0-9+/=]{43,44}$",
+              "description": "Base64-encoded Ed25519 public key (32 bytes, 43-44 chars base64)"
+            }
+          }
+        },
+        "signature": {
+          "type": "string",
+          "pattern": "^[A-Za-z0-9+/=]{86,88}$",
+          "description": "Base64-encoded Ed25519 signature"
+        }
+      }
+    },
+    "response": {
+      "type": "object",
+      "required": ["status", "swarm_id", "name", "members", "settings"],
+      "properties": {
+        "status": {
+          "type": "string",
+          "const": "accepted",
+          "description": "Join status"
+        },
+        "swarm_id": {
+          "type": "string",
+          "format": "uuid",
+          "description": "Swarm identifier"
+        },
+        "name": {
+          "type": "string",
+          "description": "Swarm name"
+        },
+        "members": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "../types/member.json"
+          },
+          "description": "All swarm members including the new member"
+        },
+        "settings": {
+          "$ref": "../types/swarm-settings.json",
+          "description": "Swarm configuration"
+        }
+      }
+    },
+    "member_joined_broadcast": {
+      "type": "object",
+      "required": ["action", "member"],
+      "properties": {
+        "action": {
+          "type": "string",
+          "const": "member_joined",
+          "description": "Broadcast action type"
+        },
+        "member": {
+          "$ref": "../types/member.json",
+          "description": "The newly joined member"
+        }
+      }
+    }
+  }
+}

--- a/schemas/operations/kick.json
+++ b/schemas/operations/kick.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/finml-sage/agent-swarm-protocol/schemas/operations/kick.json",
+  "title": "Kick Member Schemas",
+  "description": "Request and response schemas for kicking a member from a swarm",
+  "definitions": {
+    "kick_content": {
+      "type": "object",
+      "required": ["action"],
+      "properties": {
+        "action": {
+          "type": "string",
+          "const": "kicked",
+          "description": "Kick action type"
+        },
+        "reason": {
+          "type": "string",
+          "maxLength": 500,
+          "description": "Optional reason for the kick"
+        }
+      }
+    },
+    "member_kicked_broadcast": {
+      "type": "object",
+      "required": ["action", "member"],
+      "properties": {
+        "action": {
+          "type": "string",
+          "const": "member_kicked",
+          "description": "Broadcast action type"
+        },
+        "member": {
+          "type": "string",
+          "minLength": 1,
+          "description": "agent_id of the kicked member"
+        },
+        "reason": {
+          "type": "string",
+          "maxLength": 500,
+          "description": "Optional reason for the kick"
+        }
+      }
+    },
+    "response": {
+      "type": "object",
+      "required": ["status", "message_id"],
+      "properties": {
+        "status": {
+          "type": "string",
+          "const": "acknowledged",
+          "description": "Acknowledgment status"
+        },
+        "message_id": {
+          "type": "string",
+          "format": "uuid",
+          "description": "Original message identifier"
+        }
+      }
+    }
+  }
+}

--- a/schemas/operations/leave.json
+++ b/schemas/operations/leave.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/finml-sage/agent-swarm-protocol/schemas/operations/leave.json",
+  "title": "Leave Swarm Schemas",
+  "description": "Request and response schemas for leaving a swarm",
+  "definitions": {
+    "broadcast_content": {
+      "type": "object",
+      "required": ["action"],
+      "properties": {
+        "action": {
+          "type": "string",
+          "const": "member_left",
+          "description": "Leave action type"
+        }
+      }
+    },
+    "response": {
+      "type": "object",
+      "required": ["status", "message_id"],
+      "properties": {
+        "status": {
+          "type": "string",
+          "const": "acknowledged",
+          "description": "Acknowledgment status"
+        },
+        "message_id": {
+          "type": "string",
+          "format": "uuid",
+          "description": "Original message identifier"
+        }
+      }
+    },
+    "swarm_dissolved_broadcast": {
+      "type": "object",
+      "required": ["action", "reason"],
+      "properties": {
+        "action": {
+          "type": "string",
+          "const": "swarm_dissolved",
+          "description": "Dissolution action type"
+        },
+        "reason": {
+          "type": "string",
+          "enum": ["master_left"],
+          "description": "Reason for dissolution"
+        }
+      }
+    }
+  }
+}

--- a/schemas/operations/transfer.json
+++ b/schemas/operations/transfer.json
@@ -1,0 +1,72 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/finml-sage/agent-swarm-protocol/schemas/operations/transfer.json",
+  "title": "Transfer Master Role Schemas",
+  "description": "Request and response schemas for transferring the master role",
+  "definitions": {
+    "transfer_content": {
+      "type": "object",
+      "required": ["action"],
+      "properties": {
+        "action": {
+          "type": "string",
+          "const": "master_transfer",
+          "description": "Transfer action type"
+        }
+      }
+    },
+    "accept_response": {
+      "type": "object",
+      "required": ["status", "message_id"],
+      "properties": {
+        "status": {
+          "type": "string",
+          "const": "accepted",
+          "description": "Transfer acceptance status"
+        },
+        "message_id": {
+          "type": "string",
+          "format": "uuid",
+          "description": "Original message identifier"
+        }
+      }
+    },
+    "master_changed_broadcast": {
+      "type": "object",
+      "required": ["action", "old_master", "new_master"],
+      "properties": {
+        "action": {
+          "type": "string",
+          "const": "master_changed",
+          "description": "Broadcast action type"
+        },
+        "old_master": {
+          "type": "string",
+          "minLength": 1,
+          "description": "agent_id of the previous master"
+        },
+        "new_master": {
+          "type": "string",
+          "minLength": 1,
+          "description": "agent_id of the new master"
+        }
+      }
+    },
+    "response": {
+      "type": "object",
+      "required": ["status", "message_id"],
+      "properties": {
+        "status": {
+          "type": "string",
+          "const": "acknowledged",
+          "description": "Acknowledgment status"
+        },
+        "message_id": {
+          "type": "string",
+          "format": "uuid",
+          "description": "Original message identifier"
+        }
+      }
+    }
+  }
+}

--- a/schemas/types/error.json
+++ b/schemas/types/error.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/finml-sage/agent-swarm-protocol/schemas/types/error.json",
+  "title": "Error Response",
+  "description": "Standard error response format for all operations",
+  "type": "object",
+  "required": ["error"],
+  "properties": {
+    "error": {
+      "type": "object",
+      "required": ["code", "message"],
+      "properties": {
+        "code": {
+          "type": "string",
+          "enum": [
+            "INVALID_TOKEN",
+            "TOKEN_EXPIRED",
+            "TOKEN_EXHAUSTED",
+            "INVALID_SIGNATURE",
+            "NOT_AUTHORIZED",
+            "NOT_MASTER",
+            "NOT_MEMBER",
+            "INVITES_DISABLED",
+            "APPROVAL_REQUIRED",
+            "TRANSFER_DECLINED",
+            "SWARM_NOT_FOUND",
+            "MEMBER_NOT_FOUND",
+            "ALREADY_MEMBER",
+            "INVALID_SWARM_NAME",
+            "STORAGE_ERROR"
+          ],
+          "description": "Machine-readable error code"
+        },
+        "message": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Human-readable error description"
+        },
+        "details": {
+          "type": "object",
+          "additionalProperties": true,
+          "description": "Additional error context"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Implements complete swarm lifecycle operations specification (issue #1)
- Defines all six operations: Create, Invite, Join, Leave, Kick, Transfer Master
- Includes JSON schemas for request/response validation
- Defines reusable type schemas (member, settings, error)
- Documents all error responses with HTTP status codes

## Changes

### Documentation
- `docs/OPERATIONS.md` - Detailed operation specifications with JSON examples

### Schemas
- `schemas/operations/create.json` - Create swarm response schema
- `schemas/operations/invite.json` - Invite request/response schemas
- `schemas/operations/join.json` - Join request/response schemas
- `schemas/operations/leave.json` - Leave broadcast/response schemas
- `schemas/operations/kick.json` - Kick content/response schemas
- `schemas/operations/transfer.json` - Transfer master schemas

### Type Definitions
- `schemas/types/member.json` - Swarm member type
- `schemas/types/swarm-settings.json` - Swarm configuration settings
- `schemas/types/error.json` - Standard error response format

## Test plan

- [ ] Verify JSON schemas validate with draft-2020-12
- [ ] Confirm all operations have request and response examples
- [ ] Check error codes match HTTP status semantics

Closes #1

Generated with Claude Code