### PR TITLE
docs: standardize SERVER-SETUP.md to port 8080

### DIFF
--- a/docs/SERVER-SETUP.md
+++ b/docs/SERVER-SETUP.md
@@ -49,7 +49,7 @@ The Angie configuration template uses these variables:
 | Variable | Description | Example |
 |----------|-------------|---------|
 | `{{DOMAIN}}` | Your agent's fully qualified domain name | `agent.example.com` |
-| `{{UPSTREAM_PORT}}` | Port where FastAPI runs | `8000` |
+| `{{UPSTREAM_PORT}}` | Port where FastAPI runs | `8080` |
 | `{{ACME_EMAIL}}` | Email for Let's Encrypt notifications | `admin@example.com` |
 
 ### Configuration Files
@@ -71,7 +71,7 @@ cp src/server/angie.conf.template /etc/angie/angie.conf
 
 # Replace template variables
 sed -i 's/{{DOMAIN}}/agent.example.com/g' /etc/angie/angie.conf
-sed -i 's/{{UPSTREAM_PORT}}/8000/g' /etc/angie/angie.conf
+sed -i 's/{{UPSTREAM_PORT}}/8080/g' /etc/angie/angie.conf
 
 # Copy include files
 sudo mkdir -p /etc/angie/conf.d
@@ -127,7 +127,7 @@ sudo chmod +x /etc/letsencrypt/renewal-hooks/deploy/reload-angie.sh
 
 ```bash
 cd /path/to/agent-swarm-protocol
-python -m uvicorn src.server.main:app --host 127.0.0.1 --port 8000
+python -m uvicorn src.server.main:app --host 127.0.0.1 --port 8080
 ```
 
 Or with systemd:
@@ -142,7 +142,7 @@ After=network.target
 Type=simple
 User=www-data
 WorkingDirectory=/opt/agent-swarm-protocol
-ExecStart=/usr/bin/python3 -m uvicorn src.server.main:app --host 127.0.0.1 --port 8000
+ExecStart=/usr/bin/python3 -m uvicorn src.server.main:app --host 127.0.0.1 --port 8080
 Restart=always
 RestartSec=5
 

--- a/src/server/angie.conf.template
+++ b/src/server/angie.conf.template
@@ -1,7 +1,7 @@
 # Angie HTTP/3 Configuration for Agent Swarm Protocol
 # Template variables:
 #   {{DOMAIN}}        - Your agent's domain (e.g., agent.example.com)
-#   {{UPSTREAM_PORT}} - FastAPI application port (default: 8000)
+#   {{UPSTREAM_PORT}} - FastAPI application port (default: 8080)
 #
 # Required includes (copy to /etc/angie/conf.d/):
 #   - ssl.conf         (TLS/QUIC settings)


### PR DESCRIPTION
## Summary
- Standardize all port references in SERVER-SETUP.md from 8000 to 8080 to match Docker configuration
- Ensures consistency between SERVER-SETUP.md, docker-compose.yml, and .env.example

## Issues
Closes #33

## Test plan
- [ ] Verify all port references in SERVER-SETUP.md are 8080
- [ ] Cross-reference with docker-compose.yml handler service port
- [ ] Cross-reference with .env.example PORT variable default

🤖 Generated with [Claude Code](https://claude.com/claude-code)