### PR TITLE
docs: fix uvicorn module path in SERVER-SETUP.md

### DIFF
--- a/docs/SERVER-SETUP.md
+++ b/docs/SERVER-SETUP.md
@@ -127,7 +127,7 @@ sudo chmod +x /etc/letsencrypt/renewal-hooks/deploy/reload-angie.sh
 
 ```bash
 cd /path/to/agent-swarm-protocol
-python -m uvicorn src.server.main:app --host 127.0.0.1 --port 8080
+python -m uvicorn src.server.app:create_app --factory --host 127.0.0.1 --port 8080
 ```
 
 Or with systemd:
@@ -142,7 +142,7 @@ After=network.target
 Type=simple
 User=www-data
 WorkingDirectory=/opt/agent-swarm-protocol
-ExecStart=/usr/bin/python3 -m uvicorn src.server.main:app --host 127.0.0.1 --port 8080
+ExecStart=/usr/bin/python3 -m uvicorn src.server.app:create_app --factory --host 127.0.0.1 --port 8080
 Restart=always
 RestartSec=5
 


### PR DESCRIPTION
## Summary
- Updated uvicorn module path from `src.server.main:app` to `src.server.app:create_app --factory` in the CLI example
- Updated the systemd service file example to use the correct `--factory` flag and module path
- The app uses a factory function (`create_app()`), not a module-level `app` object

## Issues
Closes #47

## Test plan
- [ ] Verify `uvicorn src.server.app:create_app --factory --host 0.0.0.0 --port 8080` starts the server correctly
- [ ] Confirm the systemd service file example uses the correct ExecStart command
- [ ] Review SERVER-SETUP.md for any other stale references

🤖 Generated with [Claude Code](https://claude.com/claude-code)