### PR TITLE
fix: add server logging config and remove client duplicate member

### DIFF
--- a/src/client/operations.py
+++ b/src/client/operations.py
@@ -34,7 +34,6 @@ async def join_swarm(transport: Transport, token_url: str, agent_id: str, endpoi
         raise TransportError(f"Join failed: {resp.get('error', {}).get('message', resp) if resp else 'Unknown'}", status)
     now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z"
     members = [SwarmMember(agent_id=m["agent_id"], endpoint=m["endpoint"], public_key=m["public_key"], joined_at=now) for m in resp.get("members", [])]
-    members.append(SwarmMember(agent_id=agent_id, endpoint=endpoint, public_key=pk_b64, joined_at=now))
     return SwarmMembership(swarm_id=tok["swarm_id"], name=resp.get("swarm_name", ""), master=tok["master"],
         members=members, joined_at=now, settings=SwarmSettings(allow_member_invite=False, require_approval=False))
 

--- a/src/server/app.py
+++ b/src/server/app.py
@@ -26,6 +26,10 @@ def create_app(config: Optional[ServerConfig] = None) -> FastAPI:
     When called without arguments (e.g. via uvicorn --factory), loads
     configuration from environment variables.
     """
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(name)s %(levelname)s %(message)s",
+    )
     if config is None:
         config = load_config_from_env()
 


### PR DESCRIPTION
## Summary
- Add `logging.basicConfig()` in `create_app()` so application-level logs are visible in `docker compose logs`
- Remove duplicate member append in client `operations.py` -- server response already includes the joining agent since PR #60 (idempotent join)
- 202 tests passing, no regressions

## Issues
Closes #61
Closes #62

## Test plan
- [ ] `docker compose logs handler` shows application-level INFO logs after join attempts
- [ ] Client join response has no duplicate members
- [ ] All 202 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)