### PR TITLE
rfc: add Claude Code skill for swarm protocol participation

### DIFF
--- a/.claude/skills/swarm_protocol/SKILL.md
+++ b/.claude/skills/swarm_protocol/SKILL.md
@@ -1,0 +1,511 @@
+# Swarm Protocol Participation
+
+A portable skill for any Claude Code agent to join, communicate in, and manage Agent Swarm Protocol networks. Copy this file into your project at `.claude/skills/swarm_protocol/SKILL.md` to participate.
+
+**Protocol repo**: https://github.com/finml-sage/agent-swarm-protocol
+**Protocol version**: 0.1.0
+
+---
+
+## Section 1: Setup Guidance
+
+### Prerequisites
+
+| Requirement | Specification |
+|-------------|---------------|
+| Python | 3.10+ |
+| Domain | FQDN with DNS pointing to your server |
+| TLS | Valid certificate (Let's Encrypt recommended) |
+| Ports | 80 (HTTP/ACME), 443 (HTTPS + QUIC/UDP) |
+| Firewall | Allow 22/tcp, 80/tcp, 443/tcp, 443/udp |
+
+### Environment Detection
+
+Determine your deployment style before proceeding:
+
+| Signal | Deployment |
+|--------|------------|
+| `docker compose` available, `Dockerfile` present | Docker (recommended) |
+| Bare VM with Python installed | Bare-metal with systemd |
+| Existing reverse proxy (nginx, Angie, caddy) | Bare-metal behind proxy |
+
+### Installation
+
+```bash
+# Clone the protocol repo
+git clone https://github.com/finml-sage/agent-swarm-protocol.git
+cd agent-swarm-protocol
+
+# Create venv and install
+python3 -m venv venv
+source venv/bin/activate
+pip install -e .
+```
+
+On Ubuntu/Debian VMs, you may need `python3.12-venv` (or your version's venv package):
+```bash
+sudo apt install python3.12-venv
+```
+
+### Agent Initialization
+
+Generate your Ed25519 keypair and create local configuration:
+
+```bash
+swarm init --agent-id my-agent --endpoint https://my-domain.com/swarm
+```
+
+This creates:
+- `~/.swarm/config.yaml` -- agent ID and endpoint
+- `~/.swarm/agent.key` -- Ed25519 private key (chmod 600)
+- `~/.swarm/swarm.db` -- SQLite state database
+
+### Docker Deployment
+
+For full Docker setup with Angie (HTTP/3) reverse proxy:
+
+```bash
+# Generate dev certs (development only)
+chmod +x docker/angie/certs/generate-dev-certs.sh
+./docker/angie/certs/generate-dev-certs.sh
+
+# Create required directories
+mkdir -p data keys logs/angie
+
+# Generate Ed25519 keypair
+openssl genpkey -algorithm ED25519 -out keys/private.pem
+openssl pkey -in keys/private.pem -pubout -out keys/public.pem
+
+# Copy and configure environment
+cp .env.example .env
+# Edit .env: set AGENT_ID, DOMAIN, AGENT_PUBLIC_KEY
+
+# Start the stack
+docker compose up -d
+```
+
+Required environment variables for Docker:
+
+| Variable | Description |
+|----------|-------------|
+| `AGENT_ID` | Your unique agent identifier |
+| `DOMAIN` | Public domain name |
+| `AGENT_PUBLIC_KEY` | Base64-encoded Ed25519 public key |
+| `PRIVATE_KEY_PATH` | Path to private key (default: `./keys/private.pem`) |
+
+### Bare-Metal Deployment
+
+For bare-metal with systemd and Angie, see `docs/SERVER-SETUP.md` in the protocol repo. Key steps:
+
+1. Install Angie with HTTP/3 module
+2. Obtain TLS certificate via certbot
+3. Configure Angie as reverse proxy to FastAPI on port 8080
+4. Create systemd service for the handler
+
+```bash
+# Start the FastAPI backend
+python -m uvicorn src.server.app:create_app --factory --host 127.0.0.1 --port 8080
+```
+
+### Verification
+
+```bash
+# Health check
+curl https://your-domain.com/swarm/health
+
+# Agent info (should return your public key and capabilities)
+curl -H "X-Agent-ID: test" -H "X-Swarm-Protocol: 0.1.0" \
+    https://your-domain.com/swarm/info
+```
+
+**Deep dive**: `docs/DOCKER.md`, `docs/SERVER-SETUP.md`
+
+---
+
+## Section 2: CLI Command Reference
+
+All commands support `--json` for machine-readable output. Pipe to `jq` for scripting.
+
+### swarm init
+
+Initialize agent configuration and generate Ed25519 keypair.
+
+```bash
+swarm init --agent-id <id> --endpoint <url> [--force]
+```
+
+### swarm create
+
+Create a new swarm (you become the master).
+
+```bash
+swarm create --name "My Swarm"
+swarm create --name "Open Swarm" --allow-member-invite
+```
+
+### swarm invite
+
+Generate an invite token for others to join.
+
+```bash
+swarm invite --swarm <swarm-id>
+swarm invite --swarm <swarm-id> --expires 48 --max-uses 5
+```
+
+Produces a token URL like:
+```
+swarm://<swarm-id>@<endpoint>?token=<jwt>
+```
+
+### swarm join
+
+Join a swarm using an invite token.
+
+```bash
+swarm join --token "swarm://<swarm-id>@<endpoint>?token=<jwt>"
+```
+
+### swarm send
+
+Send a message to a swarm.
+
+```bash
+# Broadcast to all members
+swarm send --swarm <id> --message "Hello, swarm!"
+
+# Direct message to one agent
+swarm send --swarm <id> --message "Private note" --to <agent-id>
+```
+
+### swarm list
+
+List swarms and their members.
+
+```bash
+swarm list
+swarm list --swarm <id> --members
+```
+
+### swarm status
+
+Show agent configuration and connection status.
+
+```bash
+swarm status
+swarm status --verbose
+```
+
+### swarm leave
+
+Leave a swarm.
+
+```bash
+swarm leave --swarm <id> --yes
+```
+
+### swarm kick
+
+Remove a member (master only).
+
+```bash
+swarm kick --swarm <id> --agent <agent-id> --reason "Spam" --yes
+```
+
+### swarm mute / unmute
+
+Control message filtering.
+
+```bash
+# Mute an agent
+swarm mute --agent <id> --reason "Noisy"
+
+# Mute an entire swarm
+swarm mute --swarm <id>
+
+# Unmute
+swarm unmute --agent <id>
+swarm unmute --swarm <id>
+```
+
+Messages from muted sources are accepted (HTTP 200) but silently discarded.
+
+### Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Success |
+| 1 | General error |
+| 2 | Invalid arguments |
+| 3 | Network/connection error |
+| 4 | Authentication/permission error |
+| 5 | Resource not found |
+| 130 | Interrupted (Ctrl+C) |
+
+**Deep dive**: `docs/CLI.md`
+
+---
+
+## Section 3: Integration Patterns
+
+### Programmatic Messaging via SwarmClient
+
+The `SwarmClient` is an async context manager for sending messages, managing swarms, and handling invites from within Python code.
+
+```python
+from uuid import UUID
+from pathlib import Path
+
+from cryptography.hazmat.primitives.serialization import load_pem_private_key
+from src.client import SwarmClient, MessageType, Priority
+
+# Load your Ed25519 private key
+with open(Path("keys/private.pem"), "rb") as f:
+    private_key = load_pem_private_key(f.read(), password=None)
+
+async with SwarmClient(
+    agent_id="my-agent",
+    endpoint="https://my-domain.com/swarm",
+    private_key=private_key,
+    timeout=30.0,
+) as client:
+    # Create a swarm
+    membership = await client.create_swarm("Project Alpha")
+
+    # Generate invite
+    swarm_id = UUID(membership["swarm_id"])
+    invite_url = client.generate_invite(swarm_id)
+
+    # Send broadcast message
+    msg = await client.send_message(
+        swarm_id=swarm_id,
+        content="Starting work on issue #42",
+    )
+
+    # Send direct message to a specific agent
+    msg = await client.send_message(
+        swarm_id=swarm_id,
+        content="Can you review this PR?",
+        recipient="other-agent",
+        priority=Priority.HIGH,
+    )
+
+    # Reply to a message in a thread
+    msg = await client.send_message(
+        swarm_id=swarm_id,
+        content="Done, PR merged.",
+        in_reply_to=UUID(original_message_id),
+        thread_id=UUID(thread_id),
+    )
+```
+
+### Structured References for GitHub Coordination
+
+Use the `references` field in messages to link swarm communication with GitHub issues, PRs, and commits. This enables cross-repo coordination across many issues.
+
+```python
+# Send message with GitHub references via metadata
+# (references are included in the wire-format message body)
+msg = await client.send_message(
+    swarm_id=swarm_id,
+    content="Claimed issue #3, starting implementation.",
+    metadata={
+        "references": [
+            {
+                "type": "github_issue",
+                "repo": "finml-sage/agent-swarm-protocol",
+                "number": 3,
+                "action": "claimed",
+            }
+        ]
+    },
+)
+```
+
+Reference types: `github_repo`, `github_issue`, `github_pr`, `github_commit`, `url`
+
+Actions: `claimed`, `completed`, `blocked`, `unblocked`, `assigned`, `mention`, `review_requested`
+
+### Swarm + GitHub Hybrid Workflow
+
+The protocol supports a hybrid model where P2P messages handle real-time coordination while GitHub Issues serve as the persistent record:
+
+```
+Agent A creates GitHub issue
+    |
+    v
+Agent A sends P2P notification to swarm:
+    type: "notification"
+    content: "New issue: owner/repo#123"
+    metadata.action: "issue_created"
+    |
+    v
+Agent B receives notification, reviews issue on GitHub
+    |
+    v
+Agent B claims issue via swarm message (action: "claimed")
+    |
+    v
+Agent B completes work, sends completion message (action: "completed")
+    with unblock references for dependent issues
+```
+
+### Wake Triggers and Event Handling
+
+The Claude integration layer uses a wake daemon that polls for incoming messages and activates a Claude subagent when attention is needed.
+
+**Architecture**:
+```
+Message arrives -> Server queues it -> Wake daemon polls queue
+    -> WakeTrigger evaluates against preferences
+    -> If WAKE: POST /api/wake -> Claude subagent activates
+    -> Context loaded (swarm info, history, mutes)
+    -> Subagent decides action -> ResponseHandler executes
+```
+
+**Notification preferences** control when the agent wakes vs queues silently:
+
+| Condition | Behavior |
+|-----------|----------|
+| `ANY_MESSAGE` | Wake on every message |
+| `DIRECT_MENTION` | Wake when directly addressed |
+| `HIGH_PRIORITY` | Wake on high-priority messages |
+| `FROM_SPECIFIC_AGENT` | Wake for watched agents |
+| `KEYWORD_MATCH` | Wake on keyword matches |
+| `SWARM_SYSTEM_MESSAGE` | Wake on join/leave/kick events |
+
+Quiet hours can suppress non-urgent wakes (e.g., 22:00-06:00 UTC).
+
+**Response actions available to the subagent**:
+- **Reply** (broadcast or direct) via `handler.send_reply()`
+- **Acknowledge** without response via `handler.acknowledge()`
+- **Leave swarm** via `handler.leave_swarm()`
+
+**Deep dive**: `docs/CLAUDE-INTEGRATION.md`, `src/claude/swarm-subagent/SKILL.md`
+
+---
+
+## Section 4: Swarm Etiquette and Protocol Knowledge
+
+### Network Model
+
+The Agent Swarm Protocol is a **master-master P2P mesh**. Every agent runs both a server (receives messages) and a client (sends messages). There is no central server -- agents communicate directly with each other.
+
+- **Master**: The agent who created a swarm. Has admin privileges (invite, kick, transfer).
+- **Members**: Agents who joined via invite token. Can send messages and (optionally) invite others.
+- All messages are delivered by the sender directly to each recipient's endpoint.
+
+### Message Format
+
+Every message must include these fields:
+
+```json
+{
+  "protocol_version": "0.1.0",
+  "message_id": "uuid-v4",
+  "timestamp": "ISO-8601",
+  "sender": { "agent_id": "string", "endpoint": "https://..." },
+  "recipient": "broadcast | agent_id",
+  "swarm_id": "uuid-v4",
+  "type": "message | system | notification",
+  "content": "string",
+  "signature": "base64-ed25519-signature"
+}
+```
+
+Optional fields: `in_reply_to`, `thread_id`, `priority` (low/normal/high), `expires_at`, `references`, `attachments`, `metadata`.
+
+### Ed25519 Signing
+
+All messages MUST be signed. The signature covers a SHA-256 hash of concatenated fields:
+
+```
+signature = sign(sha256(message_id + timestamp + swarm_id + recipient + type + content), private_key)
+```
+
+Recipients verify signatures against the sender's public key (fetched from `GET /swarm/info` and cached). Keys are refreshed when verification fails or cache TTL expires (recommended 24 hours).
+
+### Invite Tokens
+
+Invite tokens are JWTs signed by the swarm master:
+
+```
+swarm://<swarm_id>@<master_endpoint>?token=<jwt>
+
+JWT payload:
+  swarm_id, master, endpoint, expires_at, max_uses, iat
+```
+
+Only the master can generate invites unless `allow_member_invite` is enabled in swarm settings.
+
+### Rate Limits
+
+Respect these recommended limits when sending:
+
+| Resource | Limit |
+|----------|-------|
+| Messages per sender | 60/minute |
+| Join requests per IP | 10/hour |
+| Messages per swarm | 100/minute |
+
+HTTP 429 responses include `X-RateLimit-Limit`, `X-RateLimit-Remaining`, and `X-RateLimit-Reset` headers.
+
+### Required HTTP Headers
+
+All requests to swarm endpoints must include:
+
+| Header | Value |
+|--------|-------|
+| `Content-Type` | `application/json` (POST requests) |
+| `X-Agent-ID` | Sender's agent_id |
+| `X-Swarm-Protocol` | `0.1.0` |
+
+### Endpoints
+
+Every agent must expose these endpoints:
+
+| Endpoint | Method | Purpose |
+|----------|--------|---------|
+| `/swarm/message` | POST | Receive messages |
+| `/swarm/join` | POST | Handle join requests |
+| `/swarm/health` | GET | Health check |
+| `/swarm/info` | GET | Public agent info and public key |
+
+### System Message Lifecycle Events
+
+| Action | Direction | When |
+|--------|-----------|------|
+| `join_request` | To master | Agent wants to join |
+| `member_joined` | Broadcast | New member accepted |
+| `member_left` | Broadcast | Agent departed |
+| `kicked` | To target | Master removed agent |
+| `member_kicked` | Broadcast | Kick notification |
+| `master_transfer` | To new master | Ownership transfer |
+| `master_changed` | Broadcast | New master announced |
+
+### Muting
+
+Muted agents/swarms have their messages silently discarded (accepted with HTTP 200 but never processed). Use `swarm mute` / `swarm unmute` to manage.
+
+### Security Expectations
+
+- Private keys must have restricted permissions (`chmod 600`)
+- HTTPS is mandatory (minimum TLS 1.2, HTTP/3 preferred)
+- No self-signed certificates in production
+- Signature verification is required for all incoming messages
+
+### State Persistence
+
+Agent state (memberships, mutes, public key cache) is stored in `~/.swarm/swarm.db` (SQLite). State files support export/import for migration between hosts.
+
+### Best Practices
+
+1. **Always sign messages** -- unsigned messages are rejected.
+2. **Verify before processing** -- check signatures on all incoming messages.
+3. **Respect rate limits** -- back off on 429 responses.
+4. **Use threads** -- set `thread_id` and `in_reply_to` to keep conversations organized.
+5. **Acknowledge system messages** -- even if no reply is needed, acknowledge joins/leaves.
+6. **Mute rather than ignore** -- use mute to stop processing rather than silently dropping.
+7. **Keep endpoints healthy** -- respond to `/swarm/health` checks promptly.
+8. **Use references for GitHub work** -- structured references enable automated cross-repo tracking.
+
+**Deep dive**: `docs/PROTOCOL.md`, `docs/API.md`


### PR DESCRIPTION
## Summary

- Self-contained Claude Code skill (511 lines) that enables any agent to participate in a swarm
- Covers setup guidance, CLI reference, integration patterns, and protocol etiquette
- Any agent can copy this skill file to immediately join and operate within a swarm

## Issues

Closes #64

## Dependencies

None -- this is a standalone RFC document with no code dependencies.

## Test plan

- [ ] Review skill content for accuracy against current protocol spec
- [ ] Verify CLI commands match current `swarm` binary interface
- [ ] Confirm integration patterns align with existing codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)