### PR TITLE
feat: add claude-agent-sdk as optional wake dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,9 @@ dev = [
     "black>=24.0.0",
     "ruff>=0.2.0",
 ]
+wake = [
+    "claude-agent-sdk>=0.1.0",
+]
 
 [tool.hatch.build.targets.wheel]
 packages = ["src"]


### PR DESCRIPTION
## Summary

- Adds `claude-agent-sdk>=0.1.0` as an optional dependency under a new `wake` extras group in `pyproject.toml`
- Users can install with `pip install agent-swarm-protocol[wake]` to get the SDK for the wake system
- Base install (`pip install agent-swarm-protocol`) and dev install (`pip install -e ".[dev]"`) remain unaffected

Closes #91

## Test plan

- [x] `pip install -e "."` succeeds (base install, no SDK)
- [x] `pip install -e ".[dev]"` succeeds (dev extras unbroken)
- [x] All 269 existing tests pass
- [ ] `pip install -e ".[wake]"` installs `claude-agent-sdk` (skipped in CI -- SDK bundles Claude Code binary which requires auth)

🤖 Generated with [Claude Code](https://claude.com/claude-code)