### PR TITLE
docs: add WAKE_* and DB_PATH env vars to .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -57,3 +57,52 @@ RATE_LIMIT_JOIN_PER_HOUR=10
 
 # Maximum queued messages before back-pressure (default: 10000)
 QUEUE_MAX_SIZE=10000
+
+# ---------------------------------------------------------------------------
+# Optional: Database
+# ---------------------------------------------------------------------------
+
+# Path to SQLite database for message persistence and state (default: data/swarm.db)
+DB_PATH=data/swarm.db
+
+# ---------------------------------------------------------------------------
+# Optional: Wake Trigger (server-side, fires when messages arrive)
+# ---------------------------------------------------------------------------
+# When enabled, the server evaluates incoming messages against notification
+# preferences and POSTs to WAKE_ENDPOINT to activate the Claude subagent.
+
+# Enable the wake trigger (default: false)
+# WAKE_ENABLED=false
+
+# [required when WAKE_ENABLED=true] URL to POST wake notifications to.
+# Typically points to /api/wake on the same or another server.
+# WAKE_ENDPOINT=http://localhost:8080/api/wake
+
+# HTTP timeout in seconds for wake trigger POST requests (default: 5.0)
+# WAKE_TIMEOUT=5.0
+
+# ---------------------------------------------------------------------------
+# Optional: Wake Endpoint (POST /api/wake receiver)
+# ---------------------------------------------------------------------------
+# When enabled, mounts POST /api/wake which receives wake trigger POSTs
+# and invokes the agent via a pluggable method (subprocess, webhook, noop).
+
+# Enable the /api/wake endpoint (default: false)
+# WAKE_EP_ENABLED=false
+
+# Agent invocation method: subprocess, webhook, or noop (default: noop)
+# WAKE_EP_INVOKE_METHOD=noop
+
+# [required when method is subprocess or webhook]
+# For subprocess: command template, e.g. "claude-code --skill swarm {message_id}"
+# For webhook: URL to POST the wake payload to
+# WAKE_EP_INVOKE_TARGET=
+
+# Shared secret for X-Wake-Secret header authentication. Empty disables auth.
+# WAKE_EP_SECRET=
+
+# Path to session state file for invocation deduplication (default: data/session.json)
+# WAKE_EP_SESSION_FILE=data/session.json
+
+# Minutes before an active session is considered expired (default: 30)
+# WAKE_EP_SESSION_TIMEOUT=30


### PR DESCRIPTION
## Summary
- Add `DB_PATH` for SQLite database location
- Add `WAKE_ENABLED`, `WAKE_ENDPOINT`, `WAKE_TIMEOUT` for server-side wake trigger
- Add `WAKE_EP_ENABLED`, `WAKE_EP_INVOKE_METHOD`, `WAKE_EP_INVOKE_TARGET`, `WAKE_EP_SECRET`, `WAKE_EP_SESSION_FILE`, `WAKE_EP_SESSION_TIMEOUT` for /api/wake endpoint
- Wake variables are commented out by default since features are opt-in
- All variable names and defaults verified against `src/server/config.py`

Closes #78

## Test plan
- [ ] Copy `.env.example` to `.env` and verify server starts with defaults
- [ ] Verify all variables match `load_config_from_env()` in `src/server/config.py`

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>