### PR TITLE
docs: document message persistence to SQLite

### DIFF
--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -578,22 +578,44 @@ When importing:
 3. Merge or replace based on agent configuration
 4. Remove `exported_at` field after import
 
-### 9.6 Message Queue
+### 9.6 Message Queue and Persistence
 
-Incoming messages are queued for processing:
+Incoming messages are persisted to SQLite before being added to the in-memory
+queue. Persistence is handled by `MessageRepository` in
+`src/state/repositories/messages.py`.
+
+**Schema:**
 ```sql
 CREATE TABLE message_queue (
-  id INTEGER PRIMARY KEY,
-  message_id TEXT UNIQUE,
+  message_id TEXT PRIMARY KEY,
   swarm_id TEXT,
   sender_id TEXT,
-  type TEXT,
+  message_type TEXT,
   content TEXT,
   received_at TEXT,
   processed_at TEXT,
-  status TEXT DEFAULT 'pending'
+  status TEXT DEFAULT 'pending',
+  error TEXT
 );
 ```
+
+**Idempotent duplicate handling:** Re-posting a message with the same
+`message_id` is silently ignored via an `IntegrityError` catch. The
+response is always `{"status": "queued"}`.
+
+**Message statuses:** `pending`, `processing`, `completed`, `failed`
+
+**`get_recent()` method:** Retrieves recently completed messages for a swarm,
+ordered by `received_at` descending. The `limit` parameter is capped at 100.
+This is used by the context loader to provide conversation history to the
+Claude subagent.
+
+**Lifecycle:**
+1. Message received at `POST /swarm/message`
+2. Persisted to SQLite via `MessageRepository.enqueue()`
+3. Added to in-memory queue for immediate processing
+4. Wake trigger evaluates the message (if configured)
+5. Status transitions: pending -> processing -> completed/failed
 
 ## 10. Claude Code Integration
 
@@ -637,4 +659,3 @@ Agents MUST include `protocol_version` in all messages. Agents SHOULD accept mes
 - Swarm discovery (public swarm directory)
 - Reputation/trust scoring between agents
 - Multi-master swarms
-- Message persistence and sync across agent instances


### PR DESCRIPTION
## Summary
- Update `docs/PROTOCOL.md` Section 9.6: replace minimal schema with full persistence documentation including idempotent duplicate handling, message statuses, `get_recent()` method, and message lifecycle
- Remove "Message persistence and sync" from Future Considerations (Section 12) since it is now implemented
- Update `docs/api/endpoint-message.md`: change response from "received" to "queued", add duplicate handling and wake trigger side effects

Closes #80

## Test plan
- [ ] Verify schema matches `MessageRepository` implementation
- [ ] Verify response status matches actual endpoint behavior ("queued")

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>