### PR TITLE
feat: add claude-agent-sdk invoke method to AgentInvoker

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,9 @@ dev = [
     "black>=24.0.0",
     "ruff>=0.2.0",
 ]
+wake = [
+    "claude-agent-sdk>=0.1.0",
+]
 
 [tool.hatch.build.targets.wheel]
 packages = ["src"]

--- a/src/server/invoke_sdk.py
+++ b/src/server/invoke_sdk.py
@@ -1,0 +1,100 @@
+"""Claude Agent SDK invocation strategy.
+
+This module isolates the claude-agent-sdk dependency so that the
+rest of the server can import ``SdkInvokeConfig`` without requiring
+the SDK to be installed.  The actual SDK import happens inside
+``invoke_sdk()`` at call time.
+"""
+import logging
+from dataclasses import dataclass, field
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class SdkInvokeConfig:
+    """Configuration for the Claude Agent SDK invoke method.
+
+    Attributes:
+        cwd: Working directory for the Claude session.
+        permission_mode: Permission mode (e.g. 'acceptEdits').
+        max_turns: Maximum conversation turns per invocation.
+        allowed_tools: Tool names the agent may use.
+        model: Model override (None uses the CLI default).
+    """
+
+    cwd: str = "/root/nexus"
+    permission_mode: str = "acceptEdits"
+    max_turns: Optional[int] = None
+    allowed_tools: list[str] = field(
+        default_factory=lambda: [
+            "Read", "Edit", "Bash", "Glob", "Grep", "Task",
+        ]
+    )
+    model: Optional[str] = None
+
+
+def _build_prompt(payload: dict) -> str:
+    """Build the agent prompt from a wake payload."""
+    sender = payload.get("sender_id", "unknown")
+    message_id = payload.get("message_id", "unknown")
+    swarm_id = payload.get("swarm_id", "unknown")
+    return (
+        f"Incoming A2A message from {sender} "
+        f"(message_id={message_id}, swarm_id={swarm_id}).\n"
+        f"Check for new messages and process them."
+    )
+
+
+async def invoke_sdk(payload: dict, config: SdkInvokeConfig) -> str:
+    """Invoke the agent via the Claude Agent SDK.
+
+    Builds a prompt from the wake payload and calls ``query()``
+    with the configured SDK options.  Returns the session_id from
+    the ``ResultMessage`` for future conversation continuity.
+
+    Raises:
+        RuntimeError: If the SDK query completes without a ResultMessage.
+    """
+    from claude_agent_sdk import (
+        query,
+        ClaudeAgentOptions,
+        ResultMessage,
+    )
+
+    prompt = _build_prompt(payload)
+    options = ClaudeAgentOptions(
+        allowed_tools=list(config.allowed_tools),
+        permission_mode=config.permission_mode,
+        cwd=config.cwd,
+        max_turns=config.max_turns,
+        model=config.model,
+        setting_sources=["project"],
+    )
+
+    logger.info(
+        "Invoking agent via SDK (cwd=%s, sender=%s)",
+        config.cwd,
+        payload.get("sender_id", "unknown"),
+    )
+
+    session_id: Optional[str] = None
+    async for message in query(prompt=prompt, options=options):
+        if isinstance(message, ResultMessage):
+            session_id = message.session_id
+            if getattr(message, "is_error", False):
+                logger.warning(
+                    "SDK invocation completed with error, session=%s",
+                    session_id,
+                )
+            else:
+                logger.info(
+                    "SDK invocation completed, session=%s", session_id,
+                )
+            break
+
+    if session_id is None:
+        raise RuntimeError("SDK query completed without a ResultMessage")
+
+    return session_id

--- a/tests/test_invoke_sdk.py
+++ b/tests/test_invoke_sdk.py
@@ -1,0 +1,263 @@
+"""Tests for the Claude Agent SDK invoke method."""
+import sys
+from pathlib import Path
+from types import ModuleType
+from typing import AsyncIterator
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.server.config import WakeEndpointConfig
+from src.server.invoke_sdk import SdkInvokeConfig, _build_prompt, invoke_sdk
+from src.server.invoker import AgentInvoker
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _wake_payload(
+    message_id: str = "550e8400-e29b-41d4-a716-446655440000",
+    swarm_id: str = "660e8400-e29b-41d4-a716-446655440001",
+    sender_id: str = "sender-agent-123",
+    notification_level: str = "normal",
+) -> dict:
+    return {
+        "message_id": message_id,
+        "swarm_id": swarm_id,
+        "sender_id": sender_id,
+        "notification_level": notification_level,
+    }
+
+
+class FakeResultMessage:
+    """Shared fake ResultMessage used by all fake query generators."""
+
+    def __init__(
+        self,
+        session_id: str = "test-session-abc",
+        is_error: bool = False,
+    ) -> None:
+        self.session_id = session_id
+        self.is_error = is_error
+        self.subtype = "error" if is_error else "success"
+        self.duration_ms = 1000
+        self.duration_api_ms = 800
+        self.num_turns = 1
+        self.total_cost_usd = 0.01
+        self.usage = {}
+        self.result = "Done"
+
+
+def _make_fake_sdk() -> ModuleType:
+    """Create a fake claude_agent_sdk module for testing.
+
+    Uses the shared FakeResultMessage class so that isinstance checks
+    work correctly inside invoke_sdk.
+    """
+    mod = ModuleType("claude_agent_sdk")
+    mod.ClaudeAgentOptions = MagicMock  # type: ignore[attr-defined]
+    mod.ResultMessage = FakeResultMessage  # type: ignore[attr-defined]
+    return mod
+
+
+async def _fake_query_success(**kwargs) -> AsyncIterator:  # type: ignore[type-arg]
+    """Async generator that yields a successful ResultMessage."""
+    yield FakeResultMessage(session_id="session-xyz-123")
+
+
+async def _fake_query_error(**kwargs) -> AsyncIterator:  # type: ignore[type-arg]
+    """Async generator that yields an error ResultMessage."""
+    yield FakeResultMessage(session_id="session-err-456", is_error=True)
+
+
+async def _fake_query_empty(**kwargs) -> AsyncIterator:  # type: ignore[type-arg]
+    """Async generator that yields no ResultMessage."""
+    return
+    yield  # noqa: unreachable -- makes this an async generator
+
+
+async def _fake_query_raises(**kwargs) -> AsyncIterator:  # type: ignore[type-arg]
+    """Async generator that raises an exception."""
+    raise ConnectionError("SDK connection failed")
+    yield  # noqa: unreachable -- makes this an async generator
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: SdkInvokeConfig
+# ---------------------------------------------------------------------------
+
+
+class TestSdkInvokeConfig:
+    def test_defaults(self) -> None:
+        cfg = SdkInvokeConfig()
+        assert cfg.cwd == "/root/nexus"
+        assert cfg.permission_mode == "acceptEdits"
+        assert cfg.max_turns is None
+        assert "Read" in cfg.allowed_tools
+        assert "Task" in cfg.allowed_tools
+        assert cfg.model is None
+
+    def test_custom_values(self) -> None:
+        cfg = SdkInvokeConfig(
+            cwd="/tmp/custom",
+            permission_mode="plan",
+            max_turns=5,
+            allowed_tools=["Read", "Write"],
+            model="claude-sonnet-4-20250514",
+        )
+        assert cfg.cwd == "/tmp/custom"
+        assert cfg.permission_mode == "plan"
+        assert cfg.max_turns == 5
+        assert cfg.allowed_tools == ["Read", "Write"]
+        assert cfg.model == "claude-sonnet-4-20250514"
+
+    def test_frozen(self) -> None:
+        cfg = SdkInvokeConfig()
+        with pytest.raises(AttributeError):
+            cfg.cwd = "/other"  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: _build_prompt
+# ---------------------------------------------------------------------------
+
+
+class TestBuildPrompt:
+    def test_includes_sender_and_ids(self) -> None:
+        prompt = _build_prompt(_wake_payload())
+        assert "sender-agent-123" in prompt
+        assert "550e8400" in prompt
+        assert "660e8400" in prompt
+
+    def test_defaults_for_missing_fields(self) -> None:
+        prompt = _build_prompt({})
+        assert "unknown" in prompt
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: AgentInvoker with sdk method
+# ---------------------------------------------------------------------------
+
+
+class TestAgentInvokerSdk:
+    def test_sdk_method_accepted(self) -> None:
+        """SDK method is accepted when the package is available."""
+        fake_sdk = _make_fake_sdk()
+        with patch.dict(sys.modules, {"claude_agent_sdk": fake_sdk}):
+            invoker = AgentInvoker(method="sdk", target="")
+            assert invoker.method == "sdk"
+
+    def test_sdk_allows_empty_target(self) -> None:
+        """SDK method does not require a target."""
+        fake_sdk = _make_fake_sdk()
+        with patch.dict(sys.modules, {"claude_agent_sdk": fake_sdk}):
+            invoker = AgentInvoker(method="sdk", target="")
+            assert invoker.method == "sdk"
+
+    def test_sdk_rejects_when_not_installed(self) -> None:
+        """SDK method raises if claude-agent-sdk is not importable."""
+        with patch.dict(sys.modules, {"claude_agent_sdk": None}):
+            with pytest.raises(RuntimeError, match="claude-agent-sdk"):
+                AgentInvoker(method="sdk", target="")
+
+    def test_unknown_method_still_rejected(self) -> None:
+        with pytest.raises(ValueError, match="Unknown invocation method"):
+            AgentInvoker(method="magic", target="")
+
+    def test_sdk_config_passed_through(self) -> None:
+        """Custom SdkInvokeConfig is stored on the invoker."""
+        fake_sdk = _make_fake_sdk()
+        custom_cfg = SdkInvokeConfig(cwd="/custom", max_turns=3)
+        with patch.dict(sys.modules, {"claude_agent_sdk": fake_sdk}):
+            invoker = AgentInvoker(
+                method="sdk", target="", sdk_config=custom_cfg,
+            )
+            assert invoker._sdk_config.cwd == "/custom"
+            assert invoker._sdk_config.max_turns == 3
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: invoke_sdk function
+# ---------------------------------------------------------------------------
+
+
+class TestInvokeSdk:
+    @pytest.mark.asyncio
+    async def test_returns_session_id_on_success(self) -> None:
+        fake_sdk = _make_fake_sdk()
+        fake_sdk.query = _fake_query_success  # type: ignore[attr-defined]
+        with patch.dict(sys.modules, {"claude_agent_sdk": fake_sdk}):
+            result = await invoke_sdk(_wake_payload(), SdkInvokeConfig())
+        assert result == "session-xyz-123"
+
+    @pytest.mark.asyncio
+    async def test_returns_session_id_on_error_result(self) -> None:
+        fake_sdk = _make_fake_sdk()
+        fake_sdk.query = _fake_query_error  # type: ignore[attr-defined]
+        with patch.dict(sys.modules, {"claude_agent_sdk": fake_sdk}):
+            result = await invoke_sdk(_wake_payload(), SdkInvokeConfig())
+        assert result == "session-err-456"
+
+    @pytest.mark.asyncio
+    async def test_raises_on_no_result_message(self) -> None:
+        fake_sdk = _make_fake_sdk()
+        fake_sdk.query = _fake_query_empty  # type: ignore[attr-defined]
+        with patch.dict(sys.modules, {"claude_agent_sdk": fake_sdk}):
+            with pytest.raises(RuntimeError, match="without a ResultMessage"):
+                await invoke_sdk(_wake_payload(), SdkInvokeConfig())
+
+    @pytest.mark.asyncio
+    async def test_propagates_sdk_exception(self) -> None:
+        fake_sdk = _make_fake_sdk()
+        fake_sdk.query = _fake_query_raises  # type: ignore[attr-defined]
+        with patch.dict(sys.modules, {"claude_agent_sdk": fake_sdk}):
+            with pytest.raises(ConnectionError, match="SDK connection failed"):
+                await invoke_sdk(_wake_payload(), SdkInvokeConfig())
+
+    @pytest.mark.asyncio
+    async def test_uses_custom_config(self) -> None:
+        """Verify custom config is passed to ClaudeAgentOptions."""
+        fake_sdk = _make_fake_sdk()
+        captured_kwargs: dict = {}
+
+        async def capturing_query(**kwargs) -> AsyncIterator:  # type: ignore[type-arg]
+            captured_kwargs.update(kwargs)
+            yield FakeResultMessage(session_id="cap-session")
+
+        fake_sdk.query = capturing_query  # type: ignore[attr-defined]
+        cfg = SdkInvokeConfig(cwd="/my/project", max_turns=7)
+        with patch.dict(sys.modules, {"claude_agent_sdk": fake_sdk}):
+            result = await invoke_sdk(_wake_payload(), cfg)
+        assert result == "cap-session"
+        # The options object was constructed (MagicMock), verify query was called
+        assert "prompt" in captured_kwargs
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: WakeEndpointConfig SDK fields
+# ---------------------------------------------------------------------------
+
+
+class TestWakeEndpointConfigSdk:
+    def test_sdk_defaults(self) -> None:
+        cfg = WakeEndpointConfig()
+        assert cfg.sdk_cwd == "/root/nexus"
+        assert cfg.sdk_permission_mode == "acceptEdits"
+        assert cfg.sdk_max_turns is None
+        assert cfg.sdk_model is None
+
+    def test_sdk_custom_values(self) -> None:
+        cfg = WakeEndpointConfig(
+            enabled=True,
+            invoke_method="sdk",
+            sdk_cwd="/custom/path",
+            sdk_permission_mode="plan",
+            sdk_max_turns=10,
+            sdk_model="claude-sonnet-4-20250514",
+        )
+        assert cfg.sdk_cwd == "/custom/path"
+        assert cfg.sdk_permission_mode == "plan"
+        assert cfg.sdk_max_turns == 10
+        assert cfg.sdk_model == "claude-sonnet-4-20250514"


### PR DESCRIPTION
## Summary

Closes #90

- Added `sdk` invocation method to `AgentInvoker` that uses the official `claude-agent-sdk` Python package to programmatically invoke a Claude Code session when a wake event occurs
- New `invoke_sdk.py` module with `SdkInvokeConfig` dataclass and `invoke_sdk()` async function
- `WakeEndpointConfig` gains SDK-specific fields (`sdk_cwd`, `sdk_permission_mode`, `sdk_max_turns`, `sdk_model`) with corresponding env vars
- Added `[wake]` optional dependency group in `pyproject.toml` for `claude-agent-sdk`
- The SDK is an optional dependency: `_assert_sdk_available()` checks at invoker init and raises a clear error with install instructions if missing
- 17 new tests covering config defaults, prompt building, invoker integration, SDK function success/error/empty/exception paths, and config field validation

## Key Design Decisions

- **Separate module**: SDK logic lives in `invoke_sdk.py` to isolate the optional dependency. `SdkInvokeConfig` can be imported without the SDK installed; the actual `claude_agent_sdk` import happens inside `invoke_sdk()` at call time.
- **`query()` not `ClaudeSDKClient`**: Per the SDK docs, `query()` creates a new session each call, which matches the wake pattern (each wake = independent invocation). `ClaudeSDKClient` is for continuous conversations.
- **session_id returned**: `invoke_sdk()` returns the `session_id` from `ResultMessage` for future conversation continuity via `resume=session_id`.
- **No monkey patches**: Uses only official `claude-agent-sdk` APIs as required by the issue.

## Test plan

- [x] 17 new unit tests in `tests/test_invoke_sdk.py`
- [x] All 286 tests pass (269 existing + 17 new)
- [x] SDK availability check tested with both present and absent (mocked) package
- [x] Error paths: no ResultMessage, SDK exception propagation, error ResultMessage

Generated with [Claude Code](https://claude.com/claude-code)