### PR TITLE
feat: enable wake system by default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,20 @@
 # Variables marked [optional] have sensible defaults shown after the = sign.
 
 # ---------------------------------------------------------------------------
+# MIGRATION NOTE (v0.4+)
+# ---------------------------------------------------------------------------
+# Wake trigger and wake endpoint are now ENABLED BY DEFAULT.
+# If your deployment relied on wake being disabled (the previous default),
+# add these lines to your .env to restore the old behaviour:
+#
+#   WAKE_ENABLED=false
+#   WAKE_EP_ENABLED=false
+#
+# The default invoke method remains 'noop' (no agent invocation), so
+# enabling wake with no other configuration is safe -- it only means the
+# /api/wake endpoint is mounted and wake trigger POSTs are attempted.
+
+# ---------------------------------------------------------------------------
 # Identity
 # ---------------------------------------------------------------------------
 
@@ -20,6 +34,17 @@ AGENT_ENDPOINT=https://agent.example.com/swarm
 AGENT_PUBLIC_KEY=your-base64-encoded-public-key
 
 # ---------------------------------------------------------------------------
+# Database
+# ---------------------------------------------------------------------------
+
+# [optional] Path to the SQLite database file.
+# For Docker: the compose file sets this to /app/data/swarm.db inside the container.
+# For host deployment: set to a shared path so CLI, server, and hooks all use
+# the same database (e.g. /home/agent/.swarm/swarm.db).
+# Default: data/swarm.db
+DB_PATH=data/swarm.db
+
+# ---------------------------------------------------------------------------
 # Docker / Angie (used by docker-compose.yml, not by Python directly)
 # ---------------------------------------------------------------------------
 
@@ -30,17 +55,6 @@ DOMAIN=agent.example.com
 # [optional] Host path to Ed25519 private key file, mounted into the container.
 # Default: ./keys/private.pem
 PRIVATE_KEY_PATH=./keys/private.pem
-
-# ---------------------------------------------------------------------------
-# Database
-# ---------------------------------------------------------------------------
-
-# [optional] Path to the SQLite database file.
-# For Docker: the compose file sets this to /app/data/swarm.db inside the container.
-# For host deployment: set to a shared path so CLI, server, and hooks all use
-# the same database (e.g. /home/agent/.swarm/swarm.db).
-# Default: data/swarm.db
-DB_PATH=data/swarm.db
 
 # ---------------------------------------------------------------------------
 # Optional: Agent metadata
@@ -70,43 +84,63 @@ RATE_LIMIT_JOIN_PER_HOUR=10
 QUEUE_MAX_SIZE=10000
 
 # ---------------------------------------------------------------------------
-# Optional: Wake Trigger (server-side, fires when messages arrive)
+# Wake trigger (outbound: POST to wake endpoint when messages arrive)
+# Enabled by default. Set WAKE_ENABLED=false to disable.
 # ---------------------------------------------------------------------------
-# When enabled, the server evaluates incoming messages against notification
-# preferences and POSTs to WAKE_ENDPOINT to activate the Claude subagent.
 
-# Enable the wake trigger (default: false)
-# WAKE_ENABLED=false
+# [optional] Enable/disable the wake trigger (default: true)
+WAKE_ENABLED=true
 
-# [required when WAKE_ENABLED=true] URL to POST wake notifications to.
-# Typically points to /api/wake on the same or another server.
-# WAKE_ENDPOINT=http://localhost:8080/api/wake
+# [optional] URL to POST when a new message arrives (default: http://localhost:8080/api/wake)
+WAKE_ENDPOINT=http://localhost:8080/api/wake
 
-# HTTP timeout in seconds for wake trigger POST requests (default: 5.0)
-# WAKE_TIMEOUT=5.0
+# [optional] Timeout in seconds for wake POST requests (default: 5.0)
+WAKE_TIMEOUT=5.0
 
 # ---------------------------------------------------------------------------
-# Optional: Wake Endpoint (POST /api/wake receiver)
+# Wake endpoint (inbound: /api/wake receives POSTs and invokes the agent)
+# Enabled by default. Set WAKE_EP_ENABLED=false to disable.
 # ---------------------------------------------------------------------------
-# When enabled, mounts POST /api/wake which receives wake trigger POSTs
-# and invokes the agent via a pluggable method (subprocess, webhook, noop).
 
-# Enable the /api/wake endpoint (default: false)
-# WAKE_EP_ENABLED=false
+# [optional] Enable/disable the /api/wake endpoint (default: true)
+WAKE_EP_ENABLED=true
 
-# Agent invocation method: subprocess, webhook, or noop (default: noop)
-# WAKE_EP_INVOKE_METHOD=noop
+# [optional] Invocation method: 'subprocess', 'webhook', 'sdk', or 'noop' (default: noop)
+# - subprocess: runs a shell command (set WAKE_EP_INVOKE_TARGET)
+# - webhook: POSTs to a URL (set WAKE_EP_INVOKE_TARGET)
+# - sdk: invokes via Claude Agent SDK (pip install agent-swarm-protocol[wake])
+# - noop: does nothing (safe default)
+WAKE_EP_INVOKE_METHOD=noop
 
 # [required when method is subprocess or webhook]
-# For subprocess: command template, e.g. "claude-code --skill swarm {message_id}"
-# For webhook: URL to POST the wake payload to
-# WAKE_EP_INVOKE_TARGET=
+# Subprocess example: claude --prompt "Process swarm message: {message_id}"
+# Webhook example: http://localhost:9090/invoke
+#WAKE_EP_INVOKE_TARGET=
 
-# Shared secret for X-Wake-Secret header authentication. Empty disables auth.
-# WAKE_EP_SECRET=
+# [optional] Shared secret for X-Wake-Secret header authentication.
+# WARNING: When empty and WAKE_EP_ENABLED=true, the endpoint accepts
+# unauthenticated requests. Set a strong secret in production.
+#WAKE_EP_SECRET=
 
-# Path to session state file for invocation deduplication (default: data/session.json)
-# WAKE_EP_SESSION_FILE=data/session.json
+# [optional] Path to session state file for duplicate-invocation guard
+# (default: /root/.swarm/session.json)
+WAKE_EP_SESSION_FILE=/root/.swarm/session.json
 
-# Minutes before an active session is considered expired (default: 30)
-# WAKE_EP_SESSION_TIMEOUT=30
+# [optional] Minutes before an active session is considered expired (default: 30)
+WAKE_EP_SESSION_TIMEOUT=30
+
+# ---------------------------------------------------------------------------
+# Wake endpoint: Claude Agent SDK options (used when WAKE_EP_INVOKE_METHOD=sdk)
+# ---------------------------------------------------------------------------
+
+# [optional] Working directory for SDK sessions (default: /root/nexus)
+#WAKE_EP_SDK_CWD=/root/nexus
+
+# [optional] SDK permission mode (default: acceptEdits)
+#WAKE_EP_SDK_PERMISSION_MODE=acceptEdits
+
+# [optional] Maximum conversation turns per invocation
+#WAKE_EP_SDK_MAX_TURNS=
+
+# [optional] Model override (omit to use SDK default)
+#WAKE_EP_SDK_MODEL=

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,9 @@ from tempfile import TemporaryDirectory
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
 from fastapi.testclient import TestClient
 from src.server.app import create_app
-from src.server.config import ServerConfig, AgentConfig, RateLimitConfig
+from src.server.config import (
+    ServerConfig, AgentConfig, RateLimitConfig, WakeConfig, WakeEndpointConfig,
+)
 
 
 def _b64url_encode(data: bytes) -> str:
@@ -39,6 +41,8 @@ def server_config(agent_config: AgentConfig, tmp_path: Path) -> ServerConfig:
     return ServerConfig(
         agent=agent_config, rate_limit=RateLimitConfig(messages_per_minute=60, join_requests_per_hour=10),
         queue_max_size=100, db_path=tmp_path / "test.db",
+        wake=WakeConfig(enabled=False, endpoint=""),
+        wake_endpoint=WakeEndpointConfig(enabled=False),
     )
 
 

--- a/tests/test_message_persistence.py
+++ b/tests/test_message_persistence.py
@@ -7,13 +7,19 @@ import pytest
 from fastapi.testclient import TestClient
 
 from src.server.app import create_app
-from src.server.config import AgentConfig, RateLimitConfig, ServerConfig
+from src.server.config import (
+    AgentConfig, RateLimitConfig, ServerConfig, WakeConfig, WakeEndpointConfig,
+)
 from src.state.database import DatabaseManager
 from src.state.repositories.messages import MessageRepository
 
 
 def _make_config(tmp_path: Path) -> ServerConfig:
-    """Build a minimal ServerConfig pointing at a temp database."""
+    """Build a minimal ServerConfig pointing at a temp database.
+
+    Wake trigger and endpoint are explicitly disabled so persistence
+    tests run in isolation without network calls.
+    """
     return ServerConfig(
         agent=AgentConfig(
             agent_id="test-agent-001",
@@ -24,6 +30,8 @@ def _make_config(tmp_path: Path) -> ServerConfig:
         rate_limit=RateLimitConfig(messages_per_minute=100),
         queue_max_size=100,
         db_path=tmp_path / "persist.db",
+        wake=WakeConfig(enabled=False, endpoint=""),
+        wake_endpoint=WakeEndpointConfig(enabled=False),
     )
 
 

--- a/tests/test_wake_endpoint.py
+++ b/tests/test_wake_endpoint.py
@@ -35,7 +35,7 @@ def _make_config(
         rate_limit=RateLimitConfig(messages_per_minute=100),
         queue_max_size=100,
         db_path=tmp_path / "wake_ep.db",
-        wake=WakeConfig(enabled=False),
+        wake=WakeConfig(enabled=False, endpoint=""),
         wake_endpoint=WakeEndpointConfig(
             enabled=wake_ep_enabled,
             invoke_method=invoke_method,
@@ -231,16 +231,16 @@ class TestAgentInvoker:
         await invoker.invoke({"message_id": "test"})  # Should not raise
 
 
-class TestWakeEndpointConfig:
+class TestWakeEndpointConfigDefaults:
     """Test WakeEndpointConfig defaults and construction."""
 
     def test_defaults(self) -> None:
         cfg = WakeEndpointConfig()
-        assert cfg.enabled is False
+        assert cfg.enabled is True
         assert cfg.invoke_method == "noop"
         assert cfg.invoke_target == ""
         assert cfg.secret == ""
-        assert cfg.session_file == "data/session.json"
+        assert cfg.session_file == "/root/.swarm/session.json"
         assert cfg.session_timeout_minutes == 30
 
     def test_custom_values(self) -> None:


### PR DESCRIPTION
## Summary
- Enable `WAKE_ENABLED` and `WAKE_EP_ENABLED` by default so the wake system is active out of the box
- Add `_parse_bool()` helper that supports explicit default values for boolean env vars
- Fix `WakeTrigger._trigger_wake` to catch `httpx.HTTPError` and wrap as `WakeTriggerError` (prevents connection failures from crashing message flow)
- Document all `WAKE_*` and `DB_PATH` env vars in `.env.example` with defaults and descriptions
- Update all test configs to explicitly disable wake to avoid network calls in CI

Closes #89

## Test plan
- [x] All 275 tests pass (5 new tests for `_parse_bool` and updated defaults)
- [ ] Verify server starts with no WAKE env vars set (uses defaults: enabled + noop invoke)
- [ ] Verify `WAKE_ENABLED=false` disables the wake trigger
- [ ] Verify `WAKE_EP_ENABLED=false` disables the /api/wake endpoint
- [ ] Verify `WAKE_EP_INVOKE_METHOD=subprocess` with a target command invokes the agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)