### PR TITLE
fix: resolve 3 critical wake SDK invocation bugs

### DIFF
--- a/src/server/invoke_sdk.py
+++ b/src/server/invoke_sdk.py
@@ -59,6 +59,10 @@ async def invoke_sdk(
     the SDK continues the existing conversation instead of starting
     a new one.
 
+    The async for loop consumes the full generator without an early
+    ``break`` so that the SDK cancel scope exits cleanly in the
+    same task that entered it.
+
     Args:
         payload: The wake payload with message metadata.
         config: SDK invocation configuration.
@@ -107,7 +111,6 @@ async def invoke_sdk(
                 logger.info(
                     "SDK invocation completed, session=%s", session_id,
                 )
-            break
 
     if session_id is None:
         raise RuntimeError("SDK query completed without a ResultMessage")

--- a/src/server/routes/message.py
+++ b/src/server/routes/message.py
@@ -12,7 +12,7 @@ from src.server.queue import MessageQueue
 from src.state.database import DatabaseManager
 from src.state.models.message import QueuedMessage
 from src.state.repositories.messages import MessageRepository
-from src.claude.wake_trigger import WakeTrigger, WakeTriggerError
+from src.claude.wake_trigger import WakeTrigger
 
 logger = logging.getLogger(__name__)
 
@@ -59,7 +59,9 @@ def create_message_router(
                 )
         await queue.put(body)
 
-        # Fire-and-forget wake trigger evaluation (non-blocking)
+        # Fire-and-forget wake trigger evaluation (non-blocking).
+        # Catch all exceptions: wake is a side effect that must never
+        # prevent message acceptance (e.g. httpx.ReadTimeout, WakeTriggerError).
         wake_trigger: Optional[WakeTrigger] = getattr(
             request.app.state, "wake_trigger", None,
         )
@@ -71,7 +73,7 @@ def create_message_router(
                     body.message_id,
                     event.decision.value,
                 )
-            except WakeTriggerError as exc:
+            except Exception as exc:
                 # Log but do not fail the message acceptance
                 logger.warning(
                     "Wake trigger failed for message %s: %s",

--- a/src/server/routes/wake.py
+++ b/src/server/routes/wake.py
@@ -1,4 +1,5 @@
 """POST /api/wake endpoint for agent invocation."""
+import asyncio
 import logging
 from typing import Annotated, Literal, Optional
 
@@ -33,6 +34,10 @@ class WakeResponse(BaseModel):
     detail: Optional[str] = None
 
 
+# Module-level lock prevents concurrent SDK invocations (~450MB each).
+_invoke_lock = asyncio.Lock()
+
+
 def create_wake_router(
     session_manager: SessionManager,
     invoker: AgentInvoker,
@@ -51,10 +56,46 @@ def create_wake_router(
     """
     router = APIRouter()
 
+    async def _invoke_background(
+        payload: dict,
+        resume_id: Optional[str],
+        swarm_id: str,
+        sender_id: str,
+        message_id: str,
+    ) -> None:
+        """Run agent invocation and session persistence in the background.
+
+        Acquires the module-level lock to prevent multiple simultaneous
+        SDK invocations (each is ~450MB of memory).
+        """
+        if _invoke_lock.locked():
+            logger.warning(
+                "Skipping invocation for message=%s: another invocation in progress",
+                message_id,
+            )
+            return
+
+        async with _invoke_lock:
+            try:
+                new_session_id = await invoker.invoke(payload, resume=resume_id)
+            except Exception as exc:
+                logger.error("Background agent invocation failed: %s", exc)
+                return
+
+            if db_manager is not None and new_session_id is not None:
+                await persist_sdk_session(
+                    db_manager, swarm_id, sender_id, new_session_id,
+                )
+
+            logger.info(
+                "Background invocation complete for message=%s swarm=%s session=%s",
+                message_id, swarm_id, new_session_id,
+            )
+
     @router.post(
         "/api/wake",
         response_model=WakeResponse,
-        status_code=status.HTTP_200_OK,
+        status_code=status.HTTP_202_ACCEPTED,
         tags=["wake"],
     )
     async def wake_agent(
@@ -64,9 +105,9 @@ def create_wake_router(
     ) -> WakeResponse | JSONResponse:
         """Invoke the agent in response to a wake trigger.
 
-        Looks up previous SDK session for the swarm/sender pair and
-        passes it as ``resume`` to continue the conversation. Persists
-        the new session_id after invocation.
+        Returns 202 Accepted immediately and runs the invocation in
+        a background task.  An asyncio.Lock prevents multiple
+        simultaneous SDK invocations.
         """
         # Auth check
         if wake_secret and x_wake_secret != wake_secret:
@@ -77,7 +118,7 @@ def create_wake_router(
                 ).model_dump(),
             )
 
-        # Session check: avoid double-invocation
+        # Session check: avoid double-invocation (returns 200, not 202)
         session = session_manager.get_current_session()
         if session is not None and session.state == SessionState.ACTIVE:
             if session_manager.should_resume():
@@ -85,7 +126,10 @@ def create_wake_router(
                     "Agent already active (session=%s), skipping",
                     session.session_id,
                 )
-                return WakeResponse(status="already_active")
+                return JSONResponse(
+                    status_code=status.HTTP_200_OK,
+                    content=WakeResponse(status="already_active").model_dump(),
+                )
 
         # Look up previous SDK session for conversation continuity
         resume_id: Optional[str] = None
@@ -95,28 +139,18 @@ def create_wake_router(
                 session_timeout_minutes,
             )
 
-        # Invoke the agent
+        # Fire-and-forget: launch invocation in background task
         payload = body.model_dump()
-        try:
-            new_session_id = await invoker.invoke(payload, resume=resume_id)
-        except Exception as exc:
-            logger.error("Agent invocation failed: %s", exc)
-            return JSONResponse(
-                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                content=WakeResponse(
-                    status="error", detail=str(exc)
-                ).model_dump(),
+        asyncio.create_task(
+            _invoke_background(
+                payload, resume_id,
+                body.swarm_id, body.sender_id, body.message_id,
             )
-
-        # Persist new SDK session_id for future continuity
-        if db_manager is not None and new_session_id is not None:
-            await persist_sdk_session(
-                db_manager, body.swarm_id, body.sender_id, new_session_id,
-            )
+        )
 
         logger.info(
-            "Agent invoked for message=%s swarm=%s session=%s",
-            body.message_id, body.swarm_id, new_session_id,
+            "Wake accepted for message=%s swarm=%s (background)",
+            body.message_id, body.swarm_id,
         )
         return WakeResponse(status="invoked")
 


### PR DESCRIPTION
## Summary

Fixes three interconnected bugs in the wake system's SDK invocation path, discovered during production testing:

- **Remove `break` from `invoke_sdk` async generator** (`src/server/invoke_sdk.py`): The `break` after receiving `ResultMessage` from `query()` caused generator cleanup to crash with `RuntimeError: Attempted to exit cancel scope in a different task than it was entered in`. Since `ResultMessage` is the last message from `query()`, the `async for` loop terminates naturally without `break`.

- **Make SDK invocation fire-and-forget in wake route** (`src/server/routes/wake.py`): The `/api/wake` endpoint previously blocked for 30-60 seconds waiting for `invoker.invoke()` to complete. Now returns `202 Accepted` immediately and runs invocation via `asyncio.create_task()`. Adds an `asyncio.Lock` concurrency guard to prevent multiple simultaneous SDK invocations (~450MB each). Session persistence happens in the background task after invocation completes.

- **Broaden exception catch in message route** (`src/server/routes/message.py`): The wake trigger `try/except` now catches `Exception` instead of only `WakeTriggerError`. This prevents `httpx.ReadTimeout` and other transport errors from propagating uncaught and returning 500 on the message endpoint. Wake is a side effect that must never block message acceptance.

## Test plan

- [x] All 316 existing tests pass
- [x] New test: `test_returns_202_before_invocation_completes` verifies fire-and-forget behavior
- [x] New test: `test_invocation_error_does_not_affect_response` verifies background errors don't affect response
- [x] New test: `test_lock_exists_at_module_level` verifies concurrency lock exists
- [x] New test: `test_second_invocation_skipped_when_locked` verifies lock prevents concurrent invocations
- [x] New test: `test_message_still_queued_on_unexpected_exception` verifies non-WakeTriggerError exceptions are caught
- [x] Updated all existing wake endpoint tests to expect 202 instead of 200
- [x] `already_active` response explicitly returns 200 via JSONResponse (not 202)

🤖 Generated with [Claude Code](https://claude.com/claude-code)