### PR TITLE
feat: tmux-based wake -- direct subprocess injection into running session

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -105,10 +105,12 @@ WAKE_TIMEOUT=5.0
 # [optional] Enable/disable the /api/wake endpoint (default: true)
 WAKE_EP_ENABLED=true
 
-# [optional] Invocation method: 'subprocess', 'webhook', 'sdk', or 'noop' (default: noop)
+# [optional] Invocation method: 'subprocess', 'webhook', 'sdk', 'tmux', or 'noop' (default: noop)
 # - subprocess: runs a shell command (set WAKE_EP_INVOKE_TARGET)
 # - webhook: POSTs to a URL (set WAKE_EP_INVOKE_TARGET)
 # - sdk: invokes via Claude Agent SDK (pip install agent-swarm-protocol[wake])
+# - tmux: sends a notification into a running tmux session via send-keys
+#          (set WAKE_EP_TMUX_TARGET). No SDK required.
 # - noop: does nothing (safe default)
 WAKE_EP_INVOKE_METHOD=noop
 
@@ -144,3 +146,13 @@ WAKE_EP_SESSION_TIMEOUT=30
 
 # [optional] Model override (omit to use SDK default)
 #WAKE_EP_SDK_MODEL=
+
+# ---------------------------------------------------------------------------
+# Wake endpoint: Tmux options (used when WAKE_EP_INVOKE_METHOD=tmux)
+# ---------------------------------------------------------------------------
+
+# [required when method is tmux] Tmux session/window/pane target.
+# A notification is sent to this tmux target via 'tmux send-keys'.
+# No SDK or AI relay -- just a direct subprocess call.
+# Examples: 'main:0', 'orchestrator', 'nexus:0.0'
+#WAKE_EP_TMUX_TARGET=main:0

--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ htmlcov/
 # Docker
 data/
 logs/
+docker-compose.override.yml
 
 # Secrets - never commit
 keys/

--- a/src/server/app.py
+++ b/src/server/app.py
@@ -9,6 +9,7 @@ from pydantic import ValidationError
 from src.server.config import ServerConfig, load_config_from_env
 from src.server.errors import SwarmProtocolError, RateLimitedError
 from src.server.invoke_sdk import SdkInvokeConfig
+from src.server.invoke_tmux import TmuxInvokeConfig
 from src.server.invoker import AgentInvoker
 from src.server.middleware.rate_limit import RateLimitMiddleware
 from src.server.middleware.logging import RequestLoggingMiddleware
@@ -46,6 +47,7 @@ def _build_invoker(config: ServerConfig) -> AgentInvoker:
     """Build an AgentInvoker from the wake endpoint configuration."""
     wep = config.wake_endpoint
     sdk_config = None
+    tmux_config = None
     if wep.invoke_method == "sdk":
         sdk_config = SdkInvokeConfig(
             cwd=wep.sdk_cwd,
@@ -53,10 +55,13 @@ def _build_invoker(config: ServerConfig) -> AgentInvoker:
             max_turns=wep.sdk_max_turns,
             model=wep.sdk_model,
         )
+    if wep.invoke_method == "tmux":
+        tmux_config = TmuxInvokeConfig(tmux_target=wep.tmux_target)
     return AgentInvoker(
         method=wep.invoke_method,
         target=wep.invoke_target,
         sdk_config=sdk_config,
+        tmux_config=tmux_config,
     )
 
 

--- a/src/server/invoke_tmux.py
+++ b/src/server/invoke_tmux.py
@@ -1,0 +1,59 @@
+"""Tmux invocation strategy.
+
+Sends a notification string into a running tmux session via
+``tmux send-keys``.  This is a simple IPC mechanism -- no SDK,
+no AI relay, just format a string and deliver it.
+"""
+import asyncio
+import logging
+from dataclasses import dataclass
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class TmuxInvokeConfig:
+    """Configuration for the tmux invoke method.
+
+    Attributes:
+        tmux_target: The tmux session/window/pane target (e.g. 'main:0').
+    """
+
+    tmux_target: str
+
+
+def _format_notification(payload: dict) -> str:
+    """Build a one-line notification string from a wake payload."""
+    sender = payload.get("sender_id", "unknown")
+    return f"Wake: new message from {sender}. Read and process."
+
+
+async def invoke_tmux(payload: dict, config: TmuxInvokeConfig) -> None:
+    """Send a notification into a tmux session via ``tmux send-keys``.
+
+    Args:
+        payload: The wake payload with message metadata.
+        config: Tmux configuration (session target).
+
+    Raises:
+        RuntimeError: If the tmux command fails (non-zero exit code).
+    """
+    notification = _format_notification(payload)
+    logger.info(
+        "Sending tmux notification to target=%s", config.tmux_target,
+    )
+
+    process = await asyncio.create_subprocess_exec(
+        "tmux", "send-keys", "-t", config.tmux_target,
+        notification, "C-m",
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    stdout, stderr = await process.communicate()
+
+    if process.returncode != 0:
+        err_msg = stderr.decode().strip() if stderr else "unknown error"
+        raise RuntimeError(
+            f"tmux send-keys failed (exit {process.returncode}): {err_msg}"
+        )
+    logger.info("Tmux notification sent successfully")

--- a/src/server/invoker.py
+++ b/src/server/invoker.py
@@ -4,10 +4,11 @@ import logging
 from typing import Optional
 
 from src.server.invoke_sdk import SdkInvokeConfig
+from src.server.invoke_tmux import TmuxInvokeConfig
 
 logger = logging.getLogger(__name__)
 
-_VALID_METHODS = ("subprocess", "webhook", "noop", "sdk")
+_VALID_METHODS = ("subprocess", "webhook", "noop", "sdk", "tmux")
 _METHODS_REQUIRING_TARGET = ("subprocess", "webhook")
 
 
@@ -18,6 +19,7 @@ class AgentInvoker:
       - ``"subprocess"``: launch a command (default, generic)
       - ``"webhook"``: POST to a URL
       - ``"sdk"``: invoke via the Claude Agent SDK
+      - ``"tmux"``: send notification into a tmux session via send-keys
       - ``"noop"``: do nothing (for testing / dry-run)
     """
 
@@ -26,6 +28,7 @@ class AgentInvoker:
         method: str,
         target: str,
         sdk_config: Optional[SdkInvokeConfig] = None,
+        tmux_config: Optional[TmuxInvokeConfig] = None,
     ) -> None:
         if method not in _VALID_METHODS:
             raise ValueError(
@@ -36,9 +39,16 @@ class AgentInvoker:
             raise ValueError(f"Invocation target required for method '{method}'")
         if method == "sdk":
             _assert_sdk_available()
+        if method == "tmux":
+            if tmux_config is None:
+                raise ValueError(
+                    "tmux_config required for method 'tmux'. "
+                    "Set WAKE_EP_TMUX_TARGET to a tmux session target."
+                )
         self._method = method
         self._target = target
         self._sdk_config = sdk_config or SdkInvokeConfig()
+        self._tmux_config = tmux_config
 
     @property
     def method(self) -> str:
@@ -69,6 +79,9 @@ class AgentInvoker:
             from src.server.invoke_sdk import invoke_sdk
 
             return await invoke_sdk(payload, self._sdk_config, resume=resume)
+        if self._method == "tmux":
+            await self._invoke_tmux(payload)
+            return None
         return None
 
     async def _invoke_subprocess(self, payload: dict) -> None:
@@ -94,6 +107,15 @@ class AgentInvoker:
                 raise RuntimeError(
                     f"Webhook {self._target} returned {response.status_code}"
                 )
+
+    async def _invoke_tmux(self, payload: dict) -> None:
+        """Send notification into a tmux session via send-keys."""
+        from src.server.invoke_tmux import invoke_tmux
+
+        if self._tmux_config is None:
+            raise RuntimeError("tmux_config is None but method is 'tmux'")
+
+        await invoke_tmux(payload, self._tmux_config)
 
 
 def _assert_sdk_available() -> None:

--- a/tests/test_invoke_tmux.py
+++ b/tests/test_invoke_tmux.py
@@ -1,0 +1,238 @@
+"""Tests for the tmux invoke method (subprocess-based, no SDK)."""
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.server.config import WakeEndpointConfig
+from src.server.invoke_tmux import TmuxInvokeConfig, _format_notification, invoke_tmux
+from src.server.invoker import AgentInvoker
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _wake_payload(
+    message_id: str = "550e8400-e29b-41d4-a716-446655440000",
+    swarm_id: str = "660e8400-e29b-41d4-a716-446655440001",
+    sender_id: str = "sender-agent-123",
+    notification_level: str = "normal",
+) -> dict:
+    return {
+        "message_id": message_id,
+        "swarm_id": swarm_id,
+        "sender_id": sender_id,
+        "notification_level": notification_level,
+    }
+
+
+def _mock_process(returncode: int = 0, stderr: bytes = b"") -> MagicMock:
+    """Create a mock async subprocess with communicate()."""
+    proc = MagicMock()
+    proc.returncode = returncode
+    proc.communicate = AsyncMock(return_value=(b"", stderr))
+    return proc
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: TmuxInvokeConfig
+# ---------------------------------------------------------------------------
+
+
+class TestTmuxInvokeConfig:
+    def test_requires_tmux_target(self) -> None:
+        cfg = TmuxInvokeConfig(tmux_target="main:0")
+        assert cfg.tmux_target == "main:0"
+
+    def test_frozen(self) -> None:
+        cfg = TmuxInvokeConfig(tmux_target="main:0")
+        with pytest.raises(AttributeError):
+            cfg.tmux_target = "other"  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: _format_notification
+# ---------------------------------------------------------------------------
+
+
+class TestFormatNotification:
+    def test_includes_sender(self) -> None:
+        msg = _format_notification(_wake_payload())
+        assert "sender-agent-123" in msg
+
+    def test_defaults_for_missing_sender(self) -> None:
+        msg = _format_notification({})
+        assert "unknown" in msg
+
+    def test_is_single_line(self) -> None:
+        msg = _format_notification(_wake_payload())
+        assert "\n" not in msg
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: invoke_tmux (subprocess)
+# ---------------------------------------------------------------------------
+
+
+class TestInvokeTmux:
+    @pytest.mark.asyncio
+    async def test_calls_tmux_send_keys(self) -> None:
+        """Verifies the correct tmux send-keys command is executed."""
+        proc = _mock_process(returncode=0)
+        cfg = TmuxInvokeConfig(tmux_target="main:0")
+        with patch("src.server.invoke_tmux.asyncio.create_subprocess_exec",
+                    return_value=proc) as mock_exec:
+            await invoke_tmux(_wake_payload(), cfg)
+
+        mock_exec.assert_called_once()
+        args = mock_exec.call_args[0]
+        assert args[0] == "tmux"
+        assert args[1] == "send-keys"
+        assert args[2] == "-t"
+        assert args[3] == "main:0"
+        assert "sender-agent-123" in args[4]
+        assert args[5] == "C-m"
+
+    @pytest.mark.asyncio
+    async def test_returns_none(self) -> None:
+        """invoke_tmux returns None (no session_id)."""
+        proc = _mock_process(returncode=0)
+        cfg = TmuxInvokeConfig(tmux_target="main:0")
+        with patch("src.server.invoke_tmux.asyncio.create_subprocess_exec",
+                    return_value=proc):
+            result = await invoke_tmux(_wake_payload(), cfg)
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_raises_on_nonzero_exit(self) -> None:
+        """Non-zero exit code from tmux raises RuntimeError."""
+        proc = _mock_process(returncode=1, stderr=b"session not found: main:0")
+        cfg = TmuxInvokeConfig(tmux_target="main:0")
+        with patch("src.server.invoke_tmux.asyncio.create_subprocess_exec",
+                    return_value=proc):
+            with pytest.raises(RuntimeError, match="tmux send-keys failed"):
+                await invoke_tmux(_wake_payload(), cfg)
+
+    @pytest.mark.asyncio
+    async def test_error_message_includes_stderr(self) -> None:
+        """RuntimeError includes stderr content."""
+        proc = _mock_process(returncode=1, stderr=b"no server running")
+        cfg = TmuxInvokeConfig(tmux_target="main:0")
+        with patch("src.server.invoke_tmux.asyncio.create_subprocess_exec",
+                    return_value=proc):
+            with pytest.raises(RuntimeError, match="no server running"):
+                await invoke_tmux(_wake_payload(), cfg)
+
+    @pytest.mark.asyncio
+    async def test_custom_target(self) -> None:
+        """Tmux target from config is passed to send-keys."""
+        proc = _mock_process(returncode=0)
+        cfg = TmuxInvokeConfig(tmux_target="orchestrator:1.2")
+        with patch("src.server.invoke_tmux.asyncio.create_subprocess_exec",
+                    return_value=proc) as mock_exec:
+            await invoke_tmux(_wake_payload(), cfg)
+
+        args = mock_exec.call_args[0]
+        assert args[3] == "orchestrator:1.2"
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: AgentInvoker with tmux method
+# ---------------------------------------------------------------------------
+
+
+class TestAgentInvokerTmux:
+    def test_tmux_method_accepted(self) -> None:
+        """Tmux method is accepted (no SDK required)."""
+        tmux_cfg = TmuxInvokeConfig(tmux_target="main:0")
+        invoker = AgentInvoker(
+            method="tmux", target="", tmux_config=tmux_cfg,
+        )
+        assert invoker.method == "tmux"
+
+    def test_tmux_rejects_missing_config(self) -> None:
+        """Tmux method raises if tmux_config is not provided."""
+        with pytest.raises(ValueError, match="tmux_config required"):
+            AgentInvoker(method="tmux", target="")
+
+    def test_tmux_allows_empty_target(self) -> None:
+        """Tmux method does not require a target (uses tmux_config instead)."""
+        tmux_cfg = TmuxInvokeConfig(tmux_target="main:0")
+        invoker = AgentInvoker(
+            method="tmux", target="", tmux_config=tmux_cfg,
+        )
+        assert invoker.method == "tmux"
+
+    @pytest.mark.asyncio
+    async def test_tmux_invoke_calls_invoke_tmux(self) -> None:
+        """AgentInvoker.invoke delegates to invoke_tmux."""
+        tmux_cfg = TmuxInvokeConfig(tmux_target="main:0")
+        invoker = AgentInvoker(
+            method="tmux", target="", tmux_config=tmux_cfg,
+        )
+        with patch(
+            "src.server.invoke_tmux.invoke_tmux", new_callable=AsyncMock,
+        ) as mock:
+            result = await invoker.invoke(_wake_payload())
+        mock.assert_called_once_with(_wake_payload(), tmux_cfg)
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: WakeEndpointConfig tmux_target field
+# ---------------------------------------------------------------------------
+
+
+class TestWakeEndpointConfigTmux:
+    def test_tmux_target_default_empty(self) -> None:
+        cfg = WakeEndpointConfig()
+        assert cfg.tmux_target == ""
+
+    def test_tmux_target_custom(self) -> None:
+        cfg = WakeEndpointConfig(
+            enabled=True,
+            invoke_method="tmux",
+            tmux_target="main:0",
+        )
+        assert cfg.tmux_target == "main:0"
+        assert cfg.invoke_method == "tmux"
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: config validation for tmux method
+# ---------------------------------------------------------------------------
+
+
+class TestConfigTmuxValidation:
+    def test_missing_tmux_target_raises(self) -> None:
+        """load_config_from_env raises if tmux method lacks WAKE_EP_TMUX_TARGET."""
+        from src.server.config import load_config_from_env
+
+        env = {
+            "AGENT_ID": "test",
+            "AGENT_ENDPOINT": "https://test.example.com",
+            "AGENT_PUBLIC_KEY": "dGVzdA==",
+            "WAKE_EP_INVOKE_METHOD": "tmux",
+            "WAKE_EP_TMUX_TARGET": "",
+        }
+        with patch.dict("os.environ", env, clear=True):
+            with pytest.raises(ValueError, match="WAKE_EP_TMUX_TARGET"):
+                load_config_from_env()
+
+    def test_tmux_target_set_succeeds(self) -> None:
+        """load_config_from_env succeeds when tmux_target is set."""
+        from src.server.config import load_config_from_env
+
+        env = {
+            "AGENT_ID": "test",
+            "AGENT_ENDPOINT": "https://test.example.com",
+            "AGENT_PUBLIC_KEY": "dGVzdA==",
+            "WAKE_EP_INVOKE_METHOD": "tmux",
+            "WAKE_EP_TMUX_TARGET": "main:0",
+        }
+        with patch.dict("os.environ", env, clear=True):
+            config = load_config_from_env()
+        assert config.wake_endpoint.tmux_target == "main:0"
+        assert config.wake_endpoint.invoke_method == "tmux"


### PR DESCRIPTION
Closes #121

## Summary

New **"tmux" invoke method** for the wake endpoint. Instead of spawning a new Claude process (SDK relay with haiku), the wake endpoint now uses a direct `tmux send-keys` subprocess call to inject a notification into the already-running orchestrator's tmux session.

**Design rationale:** The orchestrator is already running in a tmux session. There is no need for an AI relay to summarize messages for another AI. Direct IPC via tmux is zero-cost and instant.

## Key Changes

- **New `invoke_tmux.py`** (59 lines) -- pure `asyncio.create_subprocess_exec`, no SDK dependency
  - `TmuxInvokeConfig` dataclass with `tmux_target` field
  - `_format_notification()` builds a one-line wake string
  - `invoke_tmux()` sends it via `tmux send-keys -t <target>`
- **Added "tmux" to pluggable invoker dispatch** (`invoker.py`)
  - New `_invoke_tmux()` method on `AgentInvoker`
  - Validation: `tmux_config` required when method is `"tmux"`
- **Config/env support** (`config.py`)
  - `WAKE_EP_INVOKE_METHOD=tmux`
  - `WAKE_EP_TMUX_TARGET` (required when method is tmux)
  - Startup validation: raises `ValueError` if target is missing
- **Updated `app.py`** for tmux config construction in `_build_invoker()`
- **Updated `.env.example`** with tmux method documentation and `WAKE_EP_TMUX_TARGET` example
- **Added `docker-compose.override.yml` to `.gitignore`**

## Files Changed

| File | Change |
|------|--------|
| `src/server/invoke_tmux.py` | **New** -- tmux invocation strategy (59 lines) |
| `src/server/invoker.py` | Added tmux to valid methods, `_invoke_tmux()` dispatch |
| `src/server/config.py` | `tmux_target` field, env var loading, validation |
| `src/server/app.py` | `TmuxInvokeConfig` construction in `_build_invoker()` |
| `.env.example` | Documented tmux method and `WAKE_EP_TMUX_TARGET` |
| `.gitignore` | Added `docker-compose.override.yml` |
| `tests/test_invoke_tmux.py` | **New** -- 18 tests covering all tmux functionality |

## Test Plan

- [x] 18 new tmux-specific tests passing
- [x] Full test suite: **334 tests passing** (zero regressions)
- [x] Tests cover: config validation, notification formatting, subprocess args, error handling, invoker integration
- [ ] Manual: set `WAKE_EP_INVOKE_METHOD=tmux` and `WAKE_EP_TMUX_TARGET=main:0`, send a swarm message, confirm notification appears in tmux session

---

Generated with [Claude Code](https://claude.com/claude-code)