### PR TITLE
cleanup: remove dead code in src/cli/

### DIFF
--- a/src/cli/commands/create.py
+++ b/src/cli/commands/create.py
@@ -1,6 +1,7 @@
 """Create a new swarm."""
 
 import asyncio
+from datetime import datetime
 
 import typer
 from rich.console import Console
@@ -10,7 +11,7 @@ from src.cli.utils import ConfigManager
 from src.cli.utils.config import ConfigError
 from src.cli.utils.validation import validate_swarm_name
 from src.client import SwarmClient
-from src.state import DatabaseManager, MembershipRepository
+from src.state import DatabaseManager
 from src.state.models import SwarmMember, SwarmMembership, SwarmSettings
 
 console = Console()
@@ -37,8 +38,6 @@ async def _create_swarm(
             allow_member_invite=allow_member_invite,
             require_approval=require_approval,
         )
-
-        from datetime import datetime
 
         membership = SwarmMembership(
             swarm_id=membership_dict["swarm_id"],

--- a/src/cli/output/formatters.py
+++ b/src/cli/output/formatters.py
@@ -1,9 +1,8 @@
 """Rich terminal output formatters."""
 
-from typing import Any, Sequence
+from typing import Sequence
 
 from rich.console import Console
-from rich.panel import Panel
 from rich.table import Table
 
 
@@ -37,15 +36,3 @@ def format_table(
     for row in rows:
         table.add_row(*row)
     console.print(table)
-
-
-def format_panel(console: Console, title: str, content: str) -> None:
-    """Display content in a panel."""
-    console.print(Panel(content, title=title))
-
-
-def format_key_value(console: Console, data: dict[str, Any]) -> None:
-    """Display key-value pairs."""
-    max_key_len = max(len(k) for k in data.keys()) if data else 0
-    for key, value in data.items():
-        console.print(f"[cyan]{key.ljust(max_key_len)}[/cyan]: {value}")

--- a/src/cli/utils/config.py
+++ b/src/cli/utils/config.py
@@ -1,9 +1,7 @@
 """Configuration file management for CLI."""
 
-import base64
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional
 
 import yaml
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
@@ -38,7 +36,7 @@ class ConfigManager:
     KEY_FILE = "agent.key"
     DB_FILE = "swarm.db"
 
-    def __init__(self, config_dir: Optional[Path] = None) -> None:
+    def __init__(self, config_dir: Path | None = None) -> None:
         self._config_dir = config_dir or self.DEFAULT_DIR
         self._config_path = self._config_dir / self.CONFIG_FILE
         self._key_path = self._config_dir / self.KEY_FILE
@@ -110,15 +108,3 @@ class ConfigManager:
             f.write(key_bytes)
 
         self._key_path.chmod(0o600)
-
-    def get_public_key_base64(self) -> str:
-        """Get public key as base64 string from saved config."""
-        config = self.load()
-        pub_bytes = config.private_key.public_key().public_bytes(
-            Encoding.Raw,
-            format=__import__(
-                "cryptography.hazmat.primitives.serialization",
-                fromlist=["PublicFormat"],
-            ).PublicFormat.Raw,
-        )
-        return base64.b64encode(pub_bytes).decode("utf-8")


### PR DESCRIPTION
## Summary
- Remove unused `MembershipRepository` import from `create.py`
- Remove dead `get_public_key_base64()` method and `base64` import from `config.py`
- Remove dead `format_panel`/`format_key_value` functions and unused `Panel` import from `formatters.py`
- Move deferred `datetime` import to top-level in `create.py`
- Modernize `Optional[Path]` to `Path | None` in `config.py`

Closes #130
Reference: #125

## Test plan
- [x] All 337 tests pass after removals
- [x] No remaining imports of removed symbols in src/ or tests/

🤖 Generated with [Claude Code](https://claude.com/claude-code)