### PR TITLE
cleanup: remove dead code in src/state/

### DIFF
--- a/src/state/__init__.py
+++ b/src/state/__init__.py
@@ -1,13 +1,13 @@
 """State management module."""
-from src.state.database import DatabaseManager, DatabaseError, DatabaseNotInitializedError
-from src.state.export import export_state, export_state_to_file, import_state, import_state_from_file, StateExportError, StateImportError
+from src.state.database import DatabaseManager, DatabaseError
+from src.state.export import export_state, export_state_to_file, import_state, import_state_from_file, StateImportError
 from src.state.join import JoinError, SwarmNotFoundError, AlreadyMemberError, ApprovalRequiredError, JoinResult, validate_and_join, lookup_swarm, member_exists
 from src.state.models import SwarmMember, SwarmSettings, SwarmMembership, QueuedMessage, MessageStatus, MutedAgent, MutedSwarm, PublicKeyEntry, SdkSession
 from src.state.repositories import MembershipRepository, MessageRepository, MuteRepository, PublicKeyRepository, SessionRepository
 from src.state.session_service import lookup_sdk_session, persist_sdk_session
 from src.state.token import TokenError, TokenSignatureError, TokenExpiredError, TokenPayloadError, InviteTokenClaims, verify_invite_token
-__all__ = ["DatabaseManager", "DatabaseError", "DatabaseNotInitializedError", "export_state", "export_state_to_file",
-           "import_state", "import_state_from_file", "StateExportError", "StateImportError",
+__all__ = ["DatabaseManager", "DatabaseError", "export_state", "export_state_to_file",
+           "import_state", "import_state_from_file", "StateImportError",
            "JoinError", "SwarmNotFoundError", "AlreadyMemberError", "ApprovalRequiredError",
            "JoinResult", "validate_and_join", "lookup_swarm", "member_exists",
            "SwarmMember", "SwarmSettings", "SwarmMembership", "QueuedMessage", "MessageStatus", "MutedAgent", "MutedSwarm",

--- a/src/state/database.py
+++ b/src/state/database.py
@@ -5,7 +5,6 @@ from pathlib import Path
 from typing import AsyncIterator
 
 class DatabaseError(Exception): pass
-class DatabaseNotInitializedError(DatabaseError): pass
 
 class DatabaseManager:
     def __init__(self, db_path: Path) -> None:
@@ -18,7 +17,6 @@ class DatabaseManager:
     async def initialize(self) -> None:
         self._db_path.parent.mkdir(parents=True, exist_ok=True)
         async with self.connection() as conn:
-            await conn.execute("PRAGMA foreign_keys = ON")
             await conn.executescript(_SCHEMA)
             await conn.commit()
         self._initialized = True

--- a/src/state/export.py
+++ b/src/state/export.py
@@ -3,13 +3,11 @@ import json
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
-import aiosqlite
 from src.state.database import DatabaseManager
 from src.state.repositories.membership import MembershipRepository
 from src.state.repositories.mutes import MuteRepository
 from src.state.repositories.keys import PublicKeyRepository
 
-class StateExportError(Exception): pass
 class StateImportError(Exception): pass
 
 async def export_state(db: DatabaseManager, agent_id: str) -> dict[str, Any]:

--- a/src/state/join.py
+++ b/src/state/join.py
@@ -1,18 +1,12 @@
 """Join flow state operations."""
-import base64
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import Optional
 
 import aiosqlite
 
 from src.state.models.member import SwarmMember, SwarmMembership
 from src.state.repositories.membership import MembershipRepository
-from src.state.token import (
-    InviteTokenClaims,
-    TokenError,
-    verify_invite_token,
-)
+from src.state.token import verify_invite_token
 
 
 class JoinError(Exception):

--- a/src/state/models/member.py
+++ b/src/state/models/member.py
@@ -1,7 +1,6 @@
 """Swarm member models."""
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Optional
 
 @dataclass(frozen=True)
 class SwarmSettings:
@@ -28,7 +27,6 @@ class SwarmMembership:
     members: tuple[SwarmMember, ...]
     joined_at: datetime
     settings: SwarmSettings = field(default_factory=SwarmSettings)
-    nickname: Optional[str] = None
     def __post_init__(self) -> None:
         if not self.swarm_id: raise ValueError("swarm_id cannot be empty")
         if not self.name: raise ValueError("name cannot be empty")

--- a/src/state/models/public_key.py
+++ b/src/state/models/public_key.py
@@ -1,6 +1,6 @@
 """Public key models."""
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import datetime
 from typing import Optional
 
 @dataclass(frozen=True)
@@ -13,6 +13,3 @@ class PublicKeyEntry:
         if not self.agent_id: raise ValueError("agent_id cannot be empty")
         if not self.public_key: raise ValueError("public_key cannot be empty")
         if self.endpoint and not self.endpoint.startswith("https://"): raise ValueError("endpoint must use HTTPS")
-    def is_stale(self, ttl_hours: int = 24) -> bool:
-        age = datetime.now(timezone.utc) - self.fetched_at.replace(tzinfo=timezone.utc)
-        return age.total_seconds() > ttl_hours * 3600

--- a/src/state/repositories/keys.py
+++ b/src/state/repositories/keys.py
@@ -1,6 +1,6 @@
 """Public key repository."""
 import aiosqlite
-from datetime import datetime, timedelta, timezone
+from datetime import datetime
 from typing import Optional
 from src.state.models.public_key import PublicKeyEntry
 
@@ -19,7 +19,4 @@ class PublicKeyRepository:
         return c.rowcount > 0
     async def get_all(self) -> list[PublicKeyEntry]:
         c = await self._conn.execute("SELECT * FROM public_keys")
-        return [PublicKeyEntry(agent_id=r["agent_id"], public_key=r["public_key"], fetched_at=datetime.fromisoformat(r["fetched_at"]), endpoint=r["endpoint"]) for r in await c.fetchall()]
-    async def get_stale(self, ttl_hours: int = 24) -> list[PublicKeyEntry]:
-        c = await self._conn.execute("SELECT * FROM public_keys WHERE fetched_at < ?", ((datetime.now(timezone.utc) - timedelta(hours=ttl_hours)).isoformat(),))
         return [PublicKeyEntry(agent_id=r["agent_id"], public_key=r["public_key"], fetched_at=datetime.fromisoformat(r["fetched_at"]), endpoint=r["endpoint"]) for r in await c.fetchall()]

--- a/src/state/token.py
+++ b/src/state/token.py
@@ -1,8 +1,8 @@
 """Invite token validation using Ed25519 signatures."""
 import base64
 import json
-import time
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from typing import Any, Optional
 
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
@@ -134,8 +134,6 @@ def verify_invite_token(
 
     if claims.get("expires_at"):
         try:
-            from datetime import datetime, timezone
-
             exp_dt = datetime.fromisoformat(claims["expires_at"])
             if exp_dt.tzinfo is None:
                 exp_dt = exp_dt.replace(tzinfo=timezone.utc)


### PR DESCRIPTION
## Summary
- Remove dead imports (`base64`, `Optional`, `TokenError`, `InviteTokenClaims` from join.py; `time` from token.py; `aiosqlite` from export.py)
- Remove unused `SwarmMembership.nickname` field
- Remove unraised `DatabaseNotInitializedError` and `StateExportError`
- Remove uncalled `PublicKeyEntry.is_stale()` and `PublicKeyRepository.get_stale()`
- Move inline `from datetime import datetime, timezone` to top-level in token.py
- Remove redundant `PRAGMA foreign_keys = ON` from `initialize()` (already in `connection()`)
- Update `__init__.py` exports to remove deleted symbols

Closes #129
Reference: #125

## Test plan
- [x] All 337 tests pass after removals
- [x] No remaining imports of removed symbols (verified via grep)
- [x] No external consumers of removed items outside `src/state/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)