### PR TITLE
docs: rewrite README for host-based deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,12 +214,10 @@ agent-swarm-protocol/
 │   ├── server/              # FastAPI message handler
 │   │   ├── app.py           # Application factory
 │   │   ├── config.py        # Server configuration
-│   │   ├── errors.py        # Error handlers
 │   │   ├── invoke_sdk.py    # Claude Agent SDK invocation
 │   │   ├── invoke_tmux.py   # Tmux session invocation
 │   │   ├── invoker.py       # Pluggable agent invocation (sdk/tmux/subprocess/webhook/noop)
 │   │   ├── notifications.py # Lifecycle event notification service
-│   │   ├── queue.py         # Message queue
 │   │   ├── angie.conf.template  # Angie reverse proxy config template
 │   │   ├── proxy_params.conf    # Proxy parameter defaults
 │   │   ├── security.conf        # Security headers config


### PR DESCRIPTION
## Summary
- Remove all Docker references (Dockerfile, docker-compose, DOCKER.md, SERVER-SETUP.md links)
- Accurately describe the project as a pip-installable Python library with CLI tool (`swarm`) and optional FastAPI server
- Replace "Docker Deployment" section with "Deployment" section covering host-based approach: pip install, systemd service, Angie reverse proxy, shared SQLite database
- Update project structure tree to remove Docker files and empty scaffold directories
- Update documentation links (HOST-DEPLOYMENT.md replaces DOCKER.md and SERVER-SETUP.md)
- Refresh status table (Phase 7 now "Host Deployment" instead of "Docker Compose Packaging")
- Add deployment stack table and component descriptions to Architecture section

Reference: #125, #134
Supersedes: #126

## Test plan
- [x] All 335 tests pass (README-only change, no code affected)
- [x] All documentation links point to files that exist (HOST-DEPLOYMENT.md, PROTOCOL.md, API.md, etc.)
- [x] No Docker references remain in README

🤖 Generated with [Claude Code](https://claude.com/claude-code)