### PR TITLE
docs: remove Docker refs from .env.example and ENVIRONMENT.md, fix stale PLAN.md

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -58,7 +58,7 @@ Phase 2: Server                    Phase 3: Client                    Phase 4: S
 7. [x] Health check endpoint
 
 ### Deliverables
-- `docker/angie/angie.conf` (was `src/server/angie.conf.template`)
+- `src/server/angie.conf.template` (Angie reverse proxy config)
 - `src/server/app.py` (was `handler.py`)
 - `src/server/routes/` (endpoint handlers)
 - `src/server/middleware/` (rate limiting, logging)
@@ -129,7 +129,7 @@ Phase 2: Server                    Phase 3: Client                    Phase 4: S
 - `src/claude/session_manager.py`
 - `src/claude/notification_preferences.py`
 - `src/server/notifications.py` (lifecycle event notification service)
-- `src/server/invoker.py` (pluggable agent invocation: subprocess/webhook/noop)
+- `src/server/invoker.py` (pluggable agent invocation: sdk/tmux/subprocess/webhook/noop)
 - `src/server/routes/wake.py` (POST /api/wake endpoint)
 - `docs/CLAUDE-INTEGRATION.md`
 
@@ -244,4 +244,4 @@ Tasks marked `parallel:yes` can be worked on simultaneously by different agents.
 ### M4: Production Ready
 - Phase 6 complete
 - Documentation complete
-- 269 tests passing across server, client, state, CLI, and Claude integration
+- 337 tests passing across server, client, state, CLI, and Claude integration


### PR DESCRIPTION
## Summary

Fixes remaining documentation accuracy issues not covered by PRs #134, #140, or #141:

- **`.env.example`**: Removed Docker/Angie section (`DOMAIN`, `PRIVATE_KEY_PATH` variables) and Docker references in `AGENT_ENDPOINT` and `DB_PATH` comments. These variables were only used by `docker-compose.yml` which is being removed in PR #134.
- **`docs/ENVIRONMENT.md`**: Removed Docker/Angie variable section, fixed wake defaults (`true` not `false`), added all 5 invoke methods (sdk, tmux, subprocess, webhook, noop), added missing SDK/tmux env vars, corrected `session_file` default, updated validation rules, fixed Quick Start instructions, replaced stale See Also links (DOCKER.md, SERVER-SETUP.md) with HOST-DEPLOYMENT.md.
- **`PLAN.md`**: Fixed Phase 2 deliverable path (`src/server/angie.conf.template` not `docker/angie/angie.conf`), listed all 5 invoke methods in Phase 5 deliverables, updated test count from 269 to 337.

## Context

This is the final docs accuracy sweep after the cleanup PRs:
- PR #134 removes Docker infrastructure files (Dockerfile, docker-compose, docker/ dir, DOCKER.md, SERVER-SETUP.md)
- PR #140 rewrites README.md for host-based deployment
- PR #141 fixes OpenAPI schemas, CLAUDE-INTEGRATION.md, and wake-related docs

This PR catches the remaining stale references in `.env.example`, `docs/ENVIRONMENT.md`, and `PLAN.md` that those PRs did not address.

## Note on ENVIRONMENT.md overlap with PR #141

Both this PR and PR #141 modify `docs/ENVIRONMENT.md`. This PR includes all the same wake-related fixes from PR #141 (defaults, invoke methods, validation rules) **plus** removes the Docker/Angie section and fixes the See Also links. The changes are compatible -- whichever merges first, the other will either fast-forward or have a trivially resolvable conflict.

## Test plan

- [x] All 337 tests pass (`python -m pytest tests/ -x -q`)
- [ ] Verify .env.example no longer references Docker, DOMAIN, or PRIVATE_KEY_PATH
- [ ] Verify ENVIRONMENT.md no longer has Docker/Angie section or broken links
- [ ] Verify PLAN.md reflects current test count and file paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)