### PR TITLE
feat: add swarm export CLI command

### DIFF
--- a/src/cli/commands/__init__.py
+++ b/src/cli/commands/__init__.py
@@ -2,6 +2,7 @@
 
 from . import (
     create,
+    export_state,
     init,
     invite,
     join,
@@ -16,6 +17,7 @@ from . import (
 
 __all__ = [
     "create",
+    "export_state",
     "init",
     "invite",
     "join",

--- a/src/cli/commands/export_state.py
+++ b/src/cli/commands/export_state.py
@@ -1,0 +1,60 @@
+"""Export agent state to JSON."""
+
+import asyncio
+import json as json_lib
+from pathlib import Path
+
+import typer
+from rich.console import Console
+
+from src.cli.output import format_error, format_success, json_output
+from src.cli.utils import ConfigManager
+from src.cli.utils.config import ConfigError
+from src.state import DatabaseManager, export_state, export_state_to_file
+
+console = Console()
+
+
+async def _export(output_path: Path | None) -> dict:
+    """Export state, optionally writing to a file."""
+    config = ConfigManager()
+    agent_config = config.load()
+    db = DatabaseManager(agent_config.db_path)
+    await db.initialize()
+
+    if output_path:
+        await export_state_to_file(db, agent_config.agent_id, output_path)
+
+    return await export_state(db, agent_config.agent_id)
+
+
+def export_command(
+    output: str | None,
+    json_flag: bool,
+) -> None:
+    """Export agent state to JSON."""
+    output_path = Path(output) if output else None
+
+    try:
+        state = asyncio.run(_export(output_path))
+    except ConfigError as e:
+        format_error(console, str(e), hint="Run 'swarm init' first")
+        raise typer.Exit(code=1)
+    except Exception as e:
+        format_error(console, f"Export failed: {e}")
+        raise typer.Exit(code=1)
+
+    if json_flag or not output_path:
+        json_output(console, state)
+        return
+
+    swarm_count = len(state.get("swarms", {}))
+    key_count = len(state.get("public_keys", {}))
+    muted_agents = len(state.get("muted_agents", []))
+    muted_swarms = len(state.get("muted_swarms", []))
+
+    format_success(console, f"State exported to {output_path}")
+    console.print(f"[cyan]Swarms:[/cyan]       {swarm_count}")
+    console.print(f"[cyan]Public Keys:[/cyan]  {key_count}")
+    console.print(f"[cyan]Muted Agents:[/cyan] {muted_agents}")
+    console.print(f"[cyan]Muted Swarms:[/cyan] {muted_swarms}")

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -4,6 +4,7 @@ import typer
 from rich.console import Console
 
 from src.cli.commands.create import create_command
+from src.cli.commands.export_state import export_command
 from src.cli.commands.init import init_command
 from src.cli.commands.invite import invite_command
 from src.cli.commands.join import join_command
@@ -137,6 +138,15 @@ def status(
 ) -> None:
     """Show agent configuration and status."""
     status_command(verbose, json_flag)
+
+
+@app.command("export")
+def export_state_cmd(
+    output: str = typer.Option(None, "-o", "--output", help="Output file path"),
+    json_flag: bool = typer.Option(False, "--json", help="Output as JSON"),
+) -> None:
+    """Export agent state to JSON."""
+    export_command(output, json_flag)
 
 
 def main() -> None:

--- a/tests/cli/test_export.py
+++ b/tests/cli/test_export.py
@@ -1,0 +1,108 @@
+"""Tests for swarm export command."""
+
+import json
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+import pytest
+from typer.testing import CliRunner
+
+from src.cli.main import app
+from src.cli.utils.config import ConfigManager
+
+runner = CliRunner()
+
+
+def _init_agent(monkeypatch, config_dir: Path) -> None:
+    """Initialize an agent for testing."""
+    monkeypatch.setattr(ConfigManager, "DEFAULT_DIR", config_dir)
+    result = runner.invoke(
+        app,
+        [
+            "init",
+            "--agent-id",
+            "test-agent",
+            "--endpoint",
+            "https://example.com/swarm",
+        ],
+    )
+    assert result.exit_code == 0
+
+
+class TestExportCommand:
+    """Tests for swarm export command."""
+
+    def test_export_without_init(self, monkeypatch):
+        """Export fails if agent is not initialized."""
+        with TemporaryDirectory() as tmpdir:
+            config_dir = Path(tmpdir) / "swarm"
+            monkeypatch.setattr(ConfigManager, "DEFAULT_DIR", config_dir)
+
+            result = runner.invoke(app, ["export"])
+
+            assert result.exit_code == 1
+            assert "swarm init" in result.stdout.lower()
+
+    def test_export_to_stdout(self, monkeypatch):
+        """Export without -o prints JSON to stdout."""
+        with TemporaryDirectory() as tmpdir:
+            config_dir = Path(tmpdir) / "swarm"
+            _init_agent(monkeypatch, config_dir)
+
+            result = runner.invoke(app, ["export"])
+
+            assert result.exit_code == 0
+            data = json.loads(result.stdout)
+            assert data["agent_id"] == "test-agent"
+            assert data["schema_version"] == "1.0.0"
+            assert "swarms" in data
+            assert "muted_agents" in data
+
+    def test_export_to_file(self, monkeypatch):
+        """Export with -o writes state to file."""
+        with TemporaryDirectory() as tmpdir:
+            config_dir = Path(tmpdir) / "swarm"
+            _init_agent(monkeypatch, config_dir)
+
+            output_path = Path(tmpdir) / "state.json"
+            result = runner.invoke(app, ["export", "-o", str(output_path)])
+
+            assert result.exit_code == 0
+            assert output_path.exists()
+            assert "exported to" in result.stdout.lower()
+
+            with open(output_path) as f:
+                data = json.load(f)
+            assert data["agent_id"] == "test-agent"
+            assert data["schema_version"] == "1.0.0"
+
+    def test_export_json_flag(self, monkeypatch):
+        """Export with --json outputs JSON even with -o."""
+        with TemporaryDirectory() as tmpdir:
+            config_dir = Path(tmpdir) / "swarm"
+            _init_agent(monkeypatch, config_dir)
+
+            output_path = Path(tmpdir) / "state.json"
+            result = runner.invoke(
+                app, ["export", "-o", str(output_path), "--json"]
+            )
+
+            assert result.exit_code == 0
+            data = json.loads(result.stdout)
+            assert data["agent_id"] == "test-agent"
+            assert output_path.exists()
+
+    def test_export_file_summary(self, monkeypatch):
+        """Export to file shows human-readable summary."""
+        with TemporaryDirectory() as tmpdir:
+            config_dir = Path(tmpdir) / "swarm"
+            _init_agent(monkeypatch, config_dir)
+
+            output_path = Path(tmpdir) / "state.json"
+            result = runner.invoke(app, ["export", "-o", str(output_path)])
+
+            assert result.exit_code == 0
+            assert "Swarms:" in result.stdout
+            assert "Public Keys:" in result.stdout
+            assert "Muted Agents:" in result.stdout
+            assert "Muted Swarms:" in result.stdout


### PR DESCRIPTION
## Summary
- Add `swarm export` command to export agent state to JSON
- Wraps existing `export_state()` / `export_state_to_file()` backend functions
- `-o/--output` writes to file with human-readable summary; omitting prints JSON to stdout
- `--json` flag for machine-readable output

Closes #144

## Test plan
- [ ] Run `pytest tests/cli/test_export.py -v` — all 5 new tests pass
- [ ] Run full test suite `pytest tests/ -x` — no regressions
- [ ] Manual: `swarm export` prints JSON state to stdout
- [ ] Manual: `swarm export -o state.json` writes file and shows summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>