### PR TITLE
docs: update messaging references from message_queue to inbox CLI

### DIFF
--- a/docs/CLAUDE-INTEGRATION.md
+++ b/docs/CLAUDE-INTEGRATION.md
@@ -388,6 +388,48 @@ Wake trigger errors in the message route are logged but never block message
 acceptance. The message is always persisted and queued regardless of wake
 trigger outcome.
 
+## Agent Messaging Quick Reference
+
+When configuring your agent's CLAUDE.md for direct messaging, use the `swarm` CLI commands instead of raw SQL queries. The CLI handles the inbox lifecycle (unread → read → archived → deleted) automatically.
+
+### Reading Messages
+
+```bash
+# Read unread messages (auto-marks as read)
+swarm messages -s <swarm-id> --status unread --limit 20
+
+# Peek without marking as read
+swarm messages -s <swarm-id> --status unread --no-mark-read
+
+# Read all messages (including read/archived)
+swarm messages -s <swarm-id> --status all --limit 20
+
+# Quick inbox count
+swarm messages -s <swarm-id> --count
+```
+
+### Sending Messages
+
+```bash
+swarm send --swarm <swarm-id> --to <agent-id> --message "<text>"
+```
+
+### Inbox Management
+
+```bash
+# Archive all read messages
+swarm messages -s <swarm-id> --archive-all
+
+# View sent messages
+swarm sent --limit 10
+```
+
+### Important Notes
+
+- **Do NOT query `message_queue` directly.** The `message_queue` table is a legacy internal table. All agent-facing messages are stored in the `inbox` table and should be accessed via the CLI or the `/api/inbox` REST API.
+- The CLI talks to the FastAPI server's `/api/inbox` endpoints. Ensure your reverse proxy (Angie/nginx) forwards `/api/inbox` and `/api/outbox` to the backend.
+- Messages have a lifecycle: `unread` → `read` → `archived` → `deleted`. The CLI auto-marks messages as `read` when displayed (use `--no-mark-read` to prevent this).
+
 ## Testing
 
 Run integration tests:

--- a/docs/HOST-DEPLOYMENT.md
+++ b/docs/HOST-DEPLOYMENT.md
@@ -313,7 +313,7 @@ The key advantage of host deployment is the shared SQLite database. All componen
 |-----------|--------|---------|
 | `swarm` CLI | Read/Write | Create swarms, invite agents, send messages |
 | FastAPI server | Read/Write | Handle inbound messages, process joins |
-| Claude hooks | Read | Check for pending messages |
+| Claude hooks | Read | Check for unread inbox messages |
 | Claude Agent SDK | Read/Write | Wake system session management |
 
 Set `DB_PATH` in the environment file to point to the same database that the CLI uses (typically `~/.swarm/swarm.db`).


### PR DESCRIPTION
## Summary

- **HOST-DEPLOYMENT.md**: Updated the Shared Database table to say "Check for unread inbox messages" instead of the stale "Check for pending messages" (which referenced the old `message_queue` table)
- **CLAUDE-INTEGRATION.md**: Added an "Agent Messaging Quick Reference" section with copy-paste `swarm` CLI commands for reading, sending, and managing inbox messages. Includes explicit warning against querying `message_queue` directly.

Closes #168

## Test plan

- [ ] Verify HOST-DEPLOYMENT.md table row reads "Check for unread inbox messages"
- [ ] Verify CLAUDE-INTEGRATION.md has the new Agent Messaging Quick Reference section before the Testing section
- [ ] Verify CLI commands in the reference match the actual `swarm messages` subcommand interface

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>