### PR TITLE
Remove message content double-truncation

### DIFF
--- a/src/cli/commands/messages.py
+++ b/src/cli/commands/messages.py
@@ -144,10 +144,6 @@ def _load_base_url() -> str:
     return _server_base_url(agent_config.endpoint)
 
 
-def _truncate(text: str, length: int) -> str:
-    return text[:length] + "..." if len(text) > length else text
-
-
 def _handle_archive(archive_id: str, json_flag: bool) -> None:
     """Archive a specific message."""
     base_url = _load_base_url()
@@ -325,7 +321,7 @@ def messages_command(
             m["sender_id"],
             m["status"],
             m["received_at"][:19],
-            _truncate(m.get("content_preview", ""), 60),
+            m.get("content_preview", ""),
         )
         for m in msgs
     ]

--- a/src/cli/commands/sent.py
+++ b/src/cli/commands/sent.py
@@ -108,7 +108,7 @@ def sent_command(
             m["recipient_id"],
             m["status"],
             m["sent_at"][:19],
-            _truncate(m["content"], 60),
+            _truncate(m["content"], 500),
         )
         for m in msgs
     ]

--- a/src/server/routes/_inbox_helpers.py
+++ b/src/server/routes/_inbox_helpers.py
@@ -16,5 +16,5 @@ def msg_to_response(m: InboxMessage) -> InboxMessageResponse:
         status=m.status.value,
         received_at=m.received_at.isoformat(),
         read_at=m.read_at.isoformat() if m.read_at else None,
-        content_preview=m.content[:200],
+        content_preview=m.content,
     )

--- a/src/server/routes/outbox.py
+++ b/src/server/routes/outbox.py
@@ -47,7 +47,7 @@ def create_outbox_router(db: DatabaseManager) -> APIRouter:
                 status=m.status.value,
                 sent_at=m.sent_at.isoformat(),
                 error=m.error,
-                content_preview=m.content[:200],
+                content_preview=m.content,
             )
             for m in messages
         ]


### PR DESCRIPTION
## Summary

Messages were being double-truncated: the server API sliced `m.content[:200]` into `content_preview`, then the CLI truncated that again to 60 chars. For a private swarm, agents had to query the SQLite DB directly to read full message content.

**Changes (4 files):**
- **`src/server/routes/_inbox_helpers.py`** -- Removed `m.content[:200]` server-side truncation; `content_preview` now passes full content
- **`src/server/routes/outbox.py`** -- Same removal of `m.content[:200]` truncation
- **`src/cli/commands/messages.py`** -- Removed 60-char CLI truncation on inbox messages; removed unused `_truncate` helper function
- **`src/cli/commands/sent.py`** -- Raised CLI truncation from 60 to 500 chars for sent messages (keeps a reasonable display limit)

## Rationale

- In a private swarm with trusted agents, message content should be fully visible
- The `content_preview` field name is retained for API compatibility, but now contains full content
- Sent messages keep a 500-char limit since the sender already knows full content; inbox messages show everything since agents need complete context to act

## Testing

All 77 tests pass (44 CLI + 33 server):
```
pytest tests/cli/ tests/server/ -q
```

## Test plan

- [ ] Verify `swarm messages` shows full message content
- [ ] Verify `swarm sent` shows up to 500 chars
- [ ] Verify server `/inbox` API returns full content in `content_preview`
- [ ] Verify server `/outbox` API returns full content in `content_preview`
- [ ] Run full test suite: `pytest tests/ -q`

🤖 Generated with [Claude Code](https://claude.com/claude-code)