### PR TITLE
feat: single-coordinator routing for GitHub monitor

### DIFF
--- a/contrib/github-monitor/config.yaml
+++ b/contrib/github-monitor/config.yaml
@@ -6,15 +6,24 @@ github:
   # Poll interval tracked internally (cron handles actual scheduling)
   poll_interval_minutes: 5
 
-# Repos to monitor (add/remove as needed)
+# Repos to monitor (private repos only) with per-repo coordinator routing.
+# Each event wakes ONE coordinator, not all agents.
 repos:
-  - finml-sage/agent-swarm-protocol
-  - finml-sage/agent-memory
-  - finml-sage/ideoon-automation
-  - vantasnerdan/agent-model-pipeline
-  - mlops-kelvin/kelvin-agent
-  - nexus-marbell/nexus-state
-  - nexus-marbell/claude-multi-chat-agent
+  finml-sage/agent-memory:
+    coordinator: finml-sage
+  finml-sage/ideoon-automation:
+    coordinator: finml-sage
+  vantasnerdan/agent-model-pipeline:
+    coordinator: kelvin
+  mlops-kelvin/kelvin-agent:
+    coordinator: kelvin
+  nexus-marbell/nexus-state:
+    coordinator: nexus-marbell
+  nexus-marbell/claude-multi-chat-agent:
+    coordinator: nexus-marbell
+
+# Fallback coordinator when repo entry is a plain string (backward compat)
+default_coordinator: nexus-marbell
 
 # User tiers - determines wake message urgency and autonomy level
 users:
@@ -32,8 +41,3 @@ users:
 # Swarm config
 swarm:
   swarm_id: "716a4150-ab9d-4b54-a2a8-f2b7c607c21e"
-  # Who to wake when activity detected (agent IDs)
-  notify:
-    - finml-sage
-    - nexus-marbell
-    - kelvin


### PR DESCRIPTION
## Summary

- Remove public repos from monitoring (`agent-swarm-protocol` is public)
- Route wake messages to single coordinator per repo instead of broadcasting to all 3 agents
- Add task chain lifecycle: coordinator decomposes, delegates, tracks until all agents confirm done
- Wake instructions explicitly state: handle within team, no Dan/user input needed
- Per-repo coordinator config with fallback to `default_coordinator`

## Motivation

Dan identified two problems:
1. Broadcasting to all 3 agents = 3x redundant token consumption for the same event
2. No task chain persistence -- each agent works independently with no coordination

## Changes

- **`config.yaml`**: Per-repo coordinator mapping, removed `agent-swarm-protocol` (public). Flat `notify` list removed.
- **`monitor.py`**: Route to single coordinator instead of iterating `notify` list. New `get_coordinator()` and `get_repo_list()` helpers. Backward-compatible with legacy list-style repo config.
- **`PROTOCOL.md`**: New Section 10 -- Task Chain Lifecycle (coordinator responsibilities, confirmation protocol, failure handling, no-principal-required execution).

## Test plan

- [x] Config YAML parses correctly
- [x] Python syntax validates
- [x] Per-repo coordinator resolution works for all 6 repos
- [x] Unknown repos fall back to `default_coordinator` (nexus-marbell)
- [x] `agent-swarm-protocol` not in monitored repo list
- [x] Principal wake message includes TASK CHAIN MANAGEMENT block
- [x] Team wake message includes TASK CHAIN MANAGEMENT block
- [x] External wake message does NOT include task chain block
- [ ] Dry run shows messages routed to single coordinator per repo
- [ ] End-to-end with `--seed` flag

Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>