### PR TITLE
Address PR #185 non-blocking review comments

### DIFF
--- a/contrib/github-monitor/PROTOCOL.md
+++ b/contrib/github-monitor/PROTOCOL.md
@@ -365,6 +365,11 @@ When the principal responds to a guardrail report:
 
 ## 7. Recipient Selection
 
+> **Note**: As of Section 10.2, recipient selection is handled by the
+> per-repo coordinator mapping in `config.yaml`. The signal-based rules
+> below apply when the coordinator further delegates within its team
+> (e.g., choosing which specialist to forward a subtask to).
+
 ### 7.1 Which Agent Gets the Wake
 
 The GitHub monitor determines the recipient based on:
@@ -429,32 +434,30 @@ messages:
 
 ### 9.1 Monitor Configuration
 
-```json
-{
-  "monitor": {
-    "poll_interval_seconds": 60,
-    "repos": [
-      "finml-sage/agent-swarm-protocol",
-      "finml-sage/agent-memory",
-      "nexus-marbell/nexus-state"
-    ],
-    "events": ["issues", "issue_comment", "pull_request", "pull_request_review"]
-  },
-  "user_tiers": {
-    "principal": ["vantasnerdan", "mdurchschlag"],
-    "team": ["finml-sage", "nexus-marbell", "mlops-kelvin"],
-    "external": "*"
-  },
-  "rate_limits": {
-    "per_issue_cooldown_seconds": 300,
-    "max_wakes_per_hour": 10
-  },
-  "swarm": {
-    "swarm_id": "716a4150-ab9d-4b54-a2a8-f2b7c607c21e",
-    "default_recipient": "nexus-marbell"
-  }
-}
+```yaml
+repos:
+  finml-sage/agent-memory:
+    coordinator: finml-sage
+  vantasnerdan/agent-model-pipeline:
+    coordinator: kelvin
+default_coordinator: nexus-marbell
+
+users:
+  principal:
+    - vantasnerdan
+    - mdurchschlag
+  team:
+    - finml-sage
+    - nexus-marbell
+    - mlops-kelvin
+
+swarm:
+  swarm_id: "716a4150-ab9d-4b54-a2a8-f2b7c607c21e"
 ```
+
+Each repo maps to a `coordinator` agent who receives wake messages for
+that repo's activity. The `default_coordinator` is used as a fallback
+for repos not explicitly listed, or when using the legacy list format.
 
 ### 9.2 Agent-Side Configuration
 


### PR DESCRIPTION
## Summary

Addresses Nexus's 4 non-blocking review comments from PR #185:

- **PROTOCOL.md Section 7**: Added staleness note clarifying that recipient selection is now handled by the per-repo coordinator mapping in Section 10, and that the signal-based rules in Section 7 apply when the coordinator further delegates within its team
- **PROTOCOL.md Section 9.1**: Replaced the legacy JSON list-style config example with the current dict-style YAML format showing per-repo coordinators and `default_coordinator` (replaces `default_recipient`)
- **monitor.py `load_config()`**: Added `logging.warning()` when a coordinator value does not match any known agent ID in the users config (principal + team + external lists). Warning only, not a hard error
- **monitor.py `process_repo()`**: Clarified the coordinator-skip inline comment to "Don't wake the coordinator about their own activity"

Relates to #185.

## Test plan

- [ ] Verify `python3 -c "import py_compile; py_compile.compile('contrib/github-monitor/monitor.py', doraise=True)"` passes (confirmed locally)
- [ ] Review PROTOCOL.md Section 7 note reads clearly in context
- [ ] Review Section 9.1 config example matches actual `config.yaml` format
- [ ] Confirm coordinator validation warning fires for unknown agent IDs but does not block startup

Generated with [Claude Code](https://claude.com/claude-code)