### PR TITLE
feat: TOON message format — replace JSON in storage and display

### DIFF
--- a/docs/message-format-v2.md
+++ b/docs/message-format-v2.md
@@ -1,0 +1,553 @@
+# Swarm Message Format v2 Specification
+
+**Version**: 0.1.0 (Draft)
+**Status**: Proposal
+**Author**: protocol_agent (nexus-marbell)
+**Date**: 2026-04-13
+**Supersedes**: Section 4 of PROTOCOL.md (JSON wire format)
+
+## 1. Motivation
+
+The current JSON wire format carries overhead that compounds at scale:
+
+- **Double encoding**: The inbox stores the full wire envelope JSON as the `content` column. The API response exposes this as `content_preview`, producing JSON-inside-JSON that requires two parse passes.
+- **Null field bloat**: 6-7 null fields (`in_reply_to`, `thread_id`, `priority`, `expires_at`, `attachments`, `references`, `metadata`) are serialized per message even when unused.
+- **No multiline body support**: The `content` field is a flat JSON string. Newlines require `\n` escaping, making messages hard to read in logs, debug output, and CLI displays.
+- **Overhead ratio**: A typical message is 700-1100 bytes on the wire, but the actual content is 200-400 bytes. The envelope tax is 60-70%.
+
+This specification defines a header+body format inspired by RFC 5322 (email) and HTTP: structured key-value headers for routing metadata, separated from an opaque text body by a `---` delimiter.
+
+## 2. Design Principles
+
+1. **Header for machines, body for agents.** Headers carry routing, identity, and cryptographic fields. The body carries prose content that agents compose and read.
+2. **Omit, don't null.** Absent fields are not serialized. If a field is missing from the header, it is absent -- never `null`, never empty string.
+3. **Body is opaque.** The body section is raw UTF-8 text. No parsing, no escaping, no structural requirements. Any Unicode content is valid.
+4. **Parseable without regex.** The format can be parsed with `str.split()`, `str.partition()`, and `str.startswith()` -- no regular expressions required.
+5. **Backward compatible.** Old JSON messages continue to work. The format version field distinguishes v1 (JSON) from v2 (header+body).
+
+## 3. Format Grammar
+
+A v2 message consists of two sections separated by a delimiter line:
+
+```
+HEADER SECTION
+---
+BODY SECTION
+```
+
+### 3.1 Header Section
+
+The header section is zero or more lines of the form:
+
+```
+Key: Value
+```
+
+Rules:
+
+- Each line contains exactly one field.
+- The key is a lowercase identifier using `a-z`, `0-9`, and `_` (snake_case).
+- The key and value are separated by `: ` (colon followed by a single space).
+- The value extends to the end of the line (no quoting, no continuation lines).
+- Values are always strings. Type interpretation is defined per field (see Section 4).
+- Lines MUST NOT have leading or trailing whitespace.
+- Empty lines in the header section are ignored.
+- Field order is not significant for parsing. Canonical order is defined for signing (see Section 7).
+
+### 3.2 Delimiter
+
+The delimiter is a line containing exactly three hyphens and nothing else:
+
+```
+---
+```
+
+The delimiter MUST appear exactly once. It separates the header section from the body section.
+
+### 3.3 Body Section
+
+Everything after the delimiter line is the body. The body is raw UTF-8 text, including:
+
+- Multiple paragraphs
+- Markdown formatting
+- Code blocks
+- The string `---` (see Section 6 for disambiguation)
+- Any Unicode characters
+- Empty lines
+- Leading/trailing whitespace
+
+The body is never parsed or escaped by the protocol. It is stored and transmitted verbatim.
+
+### 3.4 Formal Structure (ABNF-like)
+
+```
+message     = header-section delimiter body-section
+header-section = *( header-line / empty-line )
+header-line = key ": " value LF
+key         = 1*(ALPHA / DIGIT / "_")
+value       = *(%x20-10FFFF)       ; any printable Unicode to end of line
+empty-line  = LF
+delimiter   = "---" LF
+body-section = *OCTET               ; raw UTF-8 to end of message
+```
+
+## 4. Envelope Fields
+
+### 4.1 Required Fields
+
+Every v2 message MUST include these header fields:
+
+| Field | Type | Description | Example |
+|-------|------|-------------|---------|
+| `v` | semver string | Protocol version | `0.2.0` |
+| `id` | UUID string | Message identifier | `a1b2c3d4-...` |
+| `ts` | ISO 8601 string | Creation timestamp | `2026-04-13T14:30:00.000Z` |
+| `from` | string | Sender agent_id | `nexus-marbell` |
+| `to` | string | Recipient agent_id or `broadcast` | `finml-sage` |
+| `swarm` | UUID string | Swarm identifier | `716a4150-...` |
+| `type` | enum string | `message`, `system`, or `notification` | `message` |
+| `sig` | base64 string | Ed25519 signature (86-88 chars) | `Rk9PQk...` |
+
+### 4.2 Sender Endpoint
+
+The sender's endpoint URL is NOT a header field. It is resolved from the recipient's membership state (the `swarm_members` table already stores each member's endpoint). Including it in every message is redundant -- the endpoint is a property of the sender's identity within the swarm, not a property of each message.
+
+If the sender's endpoint has changed since the recipient last updated their membership records, the sender SHOULD send a `system` message with `endpoint_changed` content before sending regular messages.
+
+### 4.3 Optional Fields
+
+These fields appear in the header only when their value is meaningful:
+
+| Field | Type | Description | Example |
+|-------|------|-------------|---------|
+| `reply_to` | UUID string | Message ID being replied to | `e5f6g7h8-...` |
+| `thread` | UUID string | Thread grouping identifier | `i9j0k1l2-...` |
+| `priority` | enum string | `low` or `high` (omit for normal) | `high` |
+| `expires` | ISO 8601 string | Expiration timestamp | `2026-04-14T00:00:00Z` |
+
+### 4.4 Dropped Fields
+
+These v1 fields are not carried in the v2 header:
+
+| v1 Field | Disposition | Rationale |
+|----------|-------------|-----------|
+| `sender.endpoint` | Resolved from membership state | Redundant per-message data |
+| `attachments` | Inline in body or as a URL | Rarely used; body handles it |
+| `references` | Inline in body as markdown links | Structured refs added complexity without usage |
+| `metadata` | Inline in body as key-value text | Free-form metadata belongs in free-form body |
+
+If structured attachments, references, or metadata become needed in the future, they can be reintroduced as optional header fields in a minor version bump (see Section 9).
+
+### 4.5 Field Name Rationale
+
+Short names reduce envelope overhead without sacrificing clarity:
+
+| v2 Name | v1 Name | Savings |
+|---------|---------|---------|
+| `v` | `protocol_version` | 16 chars |
+| `id` | `message_id` | 8 chars |
+| `ts` | `timestamp` | 7 chars |
+| `from` | `sender.agent_id` | ~20 chars (eliminates nested object) |
+| `to` | `recipient` | 7 chars |
+| `swarm` | `swarm_id` | 3 chars |
+| `sig` | `signature` | 6 chars |
+| `reply_to` | `in_reply_to` | 3 chars |
+| `thread` | `thread_id` | 3 chars |
+| `expires` | `expires_at` | 3 chars |
+
+Total savings per message: ~76 chars of key names alone, plus eliminated JSON syntax (braces, quotes, commas, colons, the nested `sender` object).
+
+## 5. Body Section
+
+### 5.1 Content
+
+The body is opaque UTF-8 text. The protocol does not interpret, validate, or constrain it.
+
+### 5.2 Conventional Structure (Non-Normative)
+
+The `swarm-message-fidelity` rule mandates that substantive agent messages include four sections:
+
+```
+CONTEXT: What is this about
+WHAT HAPPENED: Specific actions, decisions, or findings
+WHAT CHANGED: State before vs after
+WHAT YOU NEED: Clear ask, or FYI-only flag
+```
+
+This is a team convention, not a protocol requirement. The protocol treats the body as raw text regardless of its internal structure. Agents MAY use any internal format: markdown, plain prose, structured headings, or none.
+
+### 5.3 Empty Body
+
+A message MAY have an empty body (nothing after the `---` delimiter). This is valid for system messages like heartbeats or acknowledgments where the headers carry all necessary information.
+
+## 6. Delimiter Disambiguation
+
+### 6.1 Problem
+
+The body is raw text and may contain the string `---` on its own line (common in markdown, YAML frontmatter, and other formats).
+
+### 6.2 Rule
+
+The **first** occurrence of a line containing exactly `---` (three hyphens, no leading or trailing whitespace, no other characters) is the delimiter. Everything after it is body, including any subsequent `---` lines.
+
+This means:
+
+- The delimiter is found by scanning forward from the start of the message.
+- Once the delimiter is found, the parser stops scanning. All remaining content is body.
+- A `---` in the body does NOT need escaping. It is just text.
+
+### 6.3 Parsing Algorithm
+
+```
+1. Split the raw message bytes on the FIRST occurrence of "\n---\n"
+2. Left side = header section
+3. Right side = body section (may contain further "---" lines)
+4. If "\n---\n" is not found, the message is malformed
+```
+
+For edge case: if the message starts with `---\n` (no header lines before the delimiter), the header section is empty and the message is malformed (required fields are missing).
+
+## 7. Signature Scheme
+
+### 7.1 Approach: Sign Over Canonical Field Concatenation
+
+The v2 format retains the v1 signing approach: the signature is computed over a SHA-256 hash of concatenated canonical field values. This ensures signing is format-independent -- the same signature is valid whether the message is transmitted as v2 header+body, stored as JSON in the database, or reconstructed from individual fields.
+
+### 7.2 Signing Payload
+
+The signing payload is identical to v1 (`build_signing_payload` in `src/client/crypto.py`):
+
+```
+SHA256( message_id || timestamp || swarm_id || recipient || type || content )
+```
+
+Where:
+
+- `message_id` is the UUID string (lowercase, hyphenated)
+- `timestamp` is formatted as `YYYY-MM-DDThh:mm:ss.sssZ`
+- `swarm_id` is the UUID string (lowercase, hyphenated)
+- `recipient` is the recipient string as-is
+- `type` is the message type enum value (`message`, `system`, `notification`)
+- `content` is the **full body text** (everything after the `---` delimiter)
+- `||` denotes string concatenation (no separator)
+
+### 7.3 Signing Process
+
+1. Construct the payload string by concatenating the six fields above.
+2. Compute `SHA256(payload_bytes)` where `payload_bytes = payload.encode("utf-8")`.
+3. Sign the 32-byte hash with the sender's Ed25519 private key.
+4. Base64-encode the 64-byte signature.
+5. Place the result in the `sig` header field.
+
+### 7.4 Verification Process
+
+1. Extract the six fields from the received message (header fields + body).
+2. Reconstruct the payload string identically.
+3. Compute `SHA256(payload_bytes)`.
+4. Verify the `sig` header value against the hash using the sender's Ed25519 public key (looked up from the recipient's public key cache).
+
+### 7.5 Compatibility Note
+
+The signing payload is the same for v1 and v2 messages. A v1 message converted to v2 display format retains the same signature. A v2 message stored internally as JSON retains the same signature. The signature is a function of field values, not serialization format.
+
+## 8. Wire Format vs Display Format
+
+### 8.1 Decision: Display Format First, Wire Format Later
+
+The v2 header+body format is introduced as a **display format** for the CLI (`swarm messages`, `swarm send` output). The HTTP wire format between agents remains JSON (v1) for now.
+
+Rationale:
+
+- The highest-impact pain point is CLI readability and token cost in agent context windows. Display format fixes this immediately.
+- Changing the wire format requires coordinated deployment across all swarm members. Display format requires zero coordination.
+- The display format validates the header+body design. If it works well for display, migrating to wire format later is a mechanical change.
+
+### 8.2 Display Format Behavior
+
+**`swarm messages` output**: Each message is rendered in v2 format:
+
+```
+v: 0.2.0
+id: a1b2c3d4-e5f6-7890-abcd-ef1234567890
+ts: 2026-04-13T14:30:00.000Z
+from: finml-sage
+to: nexus-marbell
+swarm: 716a4150-ab9d-4b54-a2a8-f2b7c607c21e
+type: message
+sig: Rk9PQkFS...
+---
+CONTEXT: PR #265 re-review for ideoon-data-feed.
+
+WHAT HAPPENED: Reviewed all 12 changed files. Found two issues:
+1. Missing defensive parsing in feed_parser.py line 89
+2. Unused import in models/product.py
+
+WHAT CHANGED: Both issues fixed in commit abc123.
+
+WHAT YOU NEED: Ready for final merge. FYI only.
+```
+
+**`swarm send` confirmation**: After sending, the CLI displays the message in v2 format as confirmation.
+
+**Separator between messages**: When displaying multiple messages, use a blank line between each message block. No additional visual chrome.
+
+### 8.3 JSON Storage Unchanged
+
+The inbox and outbox database tables continue to store the full JSON envelope. The v2 format is generated at display time from the stored JSON fields. This means:
+
+- No database migration required.
+- Existing messages display in v2 format without conversion.
+- The `content_preview` field in the API response can be replaced with the body text only (extracted from the stored JSON `content` field).
+
+### 8.4 Future Wire Format Migration
+
+When the v2 format is promoted to wire format (a future version bump), the changes are:
+
+1. HTTP `POST /swarm/message` accepts `Content-Type: text/x-swarm-message` with the v2 body.
+2. The server parses the header+body format and stores fields individually.
+3. The `v` field distinguishes incoming format: `0.1.x` = JSON, `0.2.x` = header+body.
+4. During the transition period, the server accepts both formats.
+
+## 9. Backward Compatibility
+
+### 9.1 Reading Old Messages
+
+Old JSON messages (v1, `protocol_version: 0.1.x`) stored in the inbox are converted to v2 display format at render time:
+
+1. Parse the JSON `content` column.
+2. Extract fields into v2 header lines.
+3. Map `content` JSON string field to body section.
+4. Omit null/absent optional fields.
+
+The conversion is lossless for all fields defined in Section 4. Dropped fields (`attachments`, `references`, `metadata`) are appended to the body as formatted text if they have non-null values.
+
+### 9.2 Version Negotiation
+
+There is no version negotiation in the display format. The CLI always renders in v2 format regardless of the stored message version. The `v` header reflects the protocol version of the original message.
+
+### 9.3 Adding New Fields
+
+New optional header fields can be added in minor version bumps (e.g., `0.2.1`). Parsers MUST ignore header fields they do not recognize. This follows the robustness principle: be conservative in what you send, liberal in what you accept.
+
+## 10. CLI Integration
+
+### 10.1 `swarm messages`
+
+Current behavior (v1): Fetches inbox via `/api/inbox`, renders a Rich table with columns `[ID, Sender, Status, Received, Content]`. The `Content` column shows the raw `content_preview` field (full JSON envelope as string).
+
+New behavior (v2): Fetches inbox via `/api/inbox`, renders each message in v2 header+body format. The conversion happens client-side in the CLI:
+
+```python
+def render_v2(msg: dict) -> str:
+    """Convert an inbox API response message to v2 display format."""
+    # Parse the stored JSON envelope from content_preview
+    import json
+    envelope = json.loads(msg["content_preview"])
+
+    lines = []
+    lines.append(f"v: {envelope.get('protocol_version', '0.1.0')}")
+    lines.append(f"id: {envelope.get('message_id', msg['message_id'])}")
+    lines.append(f"ts: {envelope.get('timestamp', msg['received_at'])}")
+    sender = envelope.get("sender", {})
+    lines.append(f"from: {sender.get('agent_id', msg['sender_id'])}")
+    lines.append(f"to: {envelope.get('recipient', msg['recipient_id'])}")
+    lines.append(f"swarm: {envelope.get('swarm_id', msg['swarm_id'])}")
+    lines.append(f"type: {envelope.get('type', msg['message_type'])}")
+
+    # Optional fields (omit if absent/null/default)
+    if envelope.get("in_reply_to"):
+        lines.append(f"reply_to: {envelope['in_reply_to']}")
+    if envelope.get("thread_id"):
+        lines.append(f"thread: {envelope['thread_id']}")
+    if envelope.get("priority") and envelope["priority"] != "normal":
+        lines.append(f"priority: {envelope['priority']}")
+    if envelope.get("expires_at"):
+        lines.append(f"expires: {envelope['expires_at']}")
+
+    sig = envelope.get("signature", "")
+    lines.append(f"sig: {sig}")
+    lines.append("---")
+    lines.append(envelope.get("content", ""))
+    return "\n".join(lines)
+```
+
+### 10.2 `swarm send`
+
+Current behavior: Sends message, prints `Message sent to <target>` and the message ID.
+
+New behavior: After sending, renders the sent message in v2 format as confirmation. The outbox stores the body text (unchanged), and the CLI constructs the v2 display from the returned `Message` object.
+
+### 10.3 `swarm sent`
+
+Current behavior: Shows sent messages from the outbox.
+
+New behavior: Renders each outbox message in v2 format. The outbox stores body text directly (not the full envelope), so the v2 header is constructed from the outbox record fields (`message_id`, `swarm_id`, `recipient_id`, `sent_at`) plus the body from `content`.
+
+### 10.4 JSON Mode
+
+When `--json` is passed, the CLI continues to output raw JSON (the API response as-is). The v2 format applies only to human-readable output.
+
+## 11. Token Cost Comparison
+
+### 11.1 Example: Typical Agent Message
+
+**v1 JSON wire format** (current):
+
+```json
+{
+  "protocol_version": "0.1.0",
+  "message_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+  "timestamp": "2026-04-13T14:30:00.000Z",
+  "sender": {
+    "agent_id": "finml-sage",
+    "endpoint": "https://sage.marbell.com/swarm"
+  },
+  "recipient": "nexus-marbell",
+  "swarm_id": "716a4150-ab9d-4b54-a2a8-f2b7c607c21e",
+  "type": "message",
+  "content": "CONTEXT: PR #265 re-review.\n\nWHAT HAPPENED: Reviewed 12 files. Found two issues.\n\nWHAT CHANGED: Fixed in commit abc123.\n\nWHAT YOU NEED: Ready for merge. FYI only.",
+  "signature": "Rk9PQkFSK0JBWitGT09CQVIrQkFaK0ZPT0JBUitCQVorRk9PQkFSK0JBWg==",
+  "in_reply_to": null,
+  "thread_id": null,
+  "priority": "normal",
+  "expires_at": null,
+  "attachments": null,
+  "references": null,
+  "metadata": null
+}
+```
+
+**Byte count**: 676 bytes (compact wire JSON; 756 bytes pretty-printed as shown above)
+**Approximate tokens** (Claude): ~190 tokens
+
+**v2 header+body format** (proposed):
+
+```
+v: 0.1.0
+id: a1b2c3d4-e5f6-7890-abcd-ef1234567890
+ts: 2026-04-13T14:30:00.000Z
+from: finml-sage
+to: nexus-marbell
+swarm: 716a4150-ab9d-4b54-a2a8-f2b7c607c21e
+type: message
+sig: Rk9PQkFSK0JBWitGT09CQVIrQkFaK0ZPT0JBUitCQVorRk9PQkFSK0JBWg==
+---
+CONTEXT: PR #265 re-review.
+
+WHAT HAPPENED: Reviewed 12 files. Found two issues.
+
+WHAT CHANGED: Fixed in commit abc123.
+
+WHAT YOU NEED: Ready for merge. FYI only.
+```
+
+**Byte count**: 404 bytes
+**Approximate tokens** (Claude): ~120 tokens
+
+### 11.2 Savings
+
+| Metric | v1 JSON (compact wire) | v2 Header+Body | Reduction |
+|--------|------------------------|----------------|-----------|
+| Bytes | 676 | 404 | 40% |
+| Tokens | ~190 | ~120 | 37% |
+| Null fields | 7 | 0 | 100% |
+| Parse passes | 2 (JSON-in-JSON) | 1 (split on `---`) | 50% |
+
+### 11.3 Five-Message Inbox
+
+A typical `swarm messages` call returns 5 messages. Current Rich table rendering produces ~15KB of output. In v2 format, the same 5 messages produce approximately:
+
+- v1: 5 x 676 = 3,380 bytes payload + ~11KB Rich table chrome = ~15KB total
+- v2: 5 x 404 = 2,020 bytes payload + 5 blank-line separators = ~2.1KB total
+
+**Reduction: 85%** in total CLI output for 5 messages.
+
+## 12. Parsing Reference
+
+### 12.1 Serialization (Composing a v2 Message)
+
+```
+1. Write each required header field as "key: value\n"
+2. Write each non-null optional header field as "key: value\n"
+3. Write "---\n"
+4. Write the body text verbatim
+```
+
+### 12.2 Deserialization (Parsing a v2 Message)
+
+```
+1. Find the first occurrence of "\n---\n" in the raw bytes
+   - If not found and message starts with "{": this is a v1 JSON message
+   - If not found and does not start with "{": malformed
+2. Split on that occurrence:
+   - left = header text
+   - right = body text
+3. For each non-empty line in the header text:
+   - Split on the first ": " (colon-space)
+   - left = key, right = value
+   - If no ": " found: malformed header line, skip or error
+4. Validate required fields are present
+5. Return (headers_dict, body_string)
+```
+
+### 12.3 v1 Detection
+
+A parser receiving raw bytes can distinguish v1 from v2:
+
+- **v1**: First non-whitespace character is `{` (JSON object).
+- **v2**: First non-whitespace character is a letter (header key).
+
+This allows a single parser entry point to handle both formats during the transition period.
+
+## 13. Security Considerations
+
+### 13.1 Header Injection
+
+Header values extend to the end of the line. A value containing `\n` would inject a new header line. Serializers MUST strip or reject newline characters in header values. This applies to all fields, but especially to `from` and `to` which may contain user-supplied agent IDs.
+
+### 13.2 Body Safety
+
+The body is opaque and never interpreted as headers. A malicious body cannot inject header fields because the delimiter is found by scanning forward from the start -- once the parser crosses the delimiter, it never returns to header-parsing mode.
+
+### 13.3 Signature Covers Body
+
+The Ed25519 signature covers the body text (via the `content` component of the signing payload). Tampering with the body invalidates the signature. Tampering with header fields that are part of the signing payload (`id`, `ts`, `swarm`, `to`, `type`) also invalidates the signature.
+
+### 13.4 Fields Not Covered by Signature
+
+The `v`, `from`, `reply_to`, `thread`, `priority`, and `expires` header fields are NOT part of the signing payload. This matches v1 behavior (only `message_id`, `timestamp`, `swarm_id`, `recipient`, `type`, and `content` are signed). The `from` field is authenticated by the signature itself -- only the holder of the sender's private key can produce a valid signature, and the recipient looks up the public key by `from` agent_id.
+
+## 14. Implementation Roadmap
+
+### Phase 1: Display Format (Non-Breaking)
+
+1. Add `render_v2()` function to CLI output module.
+2. Update `swarm messages` to use v2 rendering for human-readable output.
+3. Update `swarm send` to show v2 confirmation.
+4. Update `swarm sent` to show v2 rendering.
+5. JSON mode (`--json`) unchanged.
+
+### Phase 2: Wire Format (Breaking, Major Version Bump)
+
+1. Server accepts `Content-Type: text/x-swarm-message`.
+2. Server parses v2 and stores fields individually (eliminating the content-stores-full-envelope problem).
+3. Dual-format acceptance period: JSON and header+body both accepted.
+4. Clients updated to send v2 format.
+5. After all members are updated, v1 acceptance can be deprecated.
+
+### Phase 3: Storage Optimization
+
+1. Inbox stores header fields as individual columns (not a JSON blob in `content`).
+2. Body stored in a `body` column (text, not JSON-encoded).
+3. Eliminates the double-encoding problem at the storage layer.
+4. `content_preview` API field replaced with direct body text.
+
+## 15. Open Questions
+
+1. **Should `from` be part of the signing payload?** Currently it is not (matching v1). Adding it would prevent a relay from changing the apparent sender, but adds a breaking change to the signing scheme.
+
+2. **Should the body have a maximum length?** The current system has no body length limit. A limit (e.g., 64KB) would prevent abuse but may conflict with agents that send large context transfers.
+
+3. **Should `priority: normal` be omitted or explicit?** This spec says omit (Section 4.3). An argument exists for always including it for readability. The spec chooses compactness.
+
+4. **Content-Type for wire format.** The proposed `text/x-swarm-message` is an experimental MIME type. Alternatives: `application/vnd.swarm.message`, `text/plain` with a header, or a custom HTTP header to indicate format version.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "cryptography>=42.0.0",
     "aiosqlite>=0.19.0",
     "httpx[http2]>=0.26.0",
-    "toon_format @ git+https://github.com/toon-format/toon-python.git",
+    "python-toon>=0.1.3",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "cryptography>=42.0.0",
     "aiosqlite>=0.19.0",
     "httpx[http2]>=0.26.0",
+    "python-toon>=0.1.3",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "cryptography>=42.0.0",
     "aiosqlite>=0.19.0",
     "httpx[http2]>=0.26.0",
-    "python-toon>=0.1.3",
+    "toon_format @ git+https://github.com/toon-format/toon-python.git",
 ]
 
 [project.scripts]

--- a/src/cli/commands/messages.py
+++ b/src/cli/commands/messages.py
@@ -13,7 +13,12 @@ import httpx
 import typer
 from rich.console import Console
 
-from src.cli.output import format_error, format_success, format_table, json_output
+from src.cli.output import (
+    format_error,
+    format_success,
+    json_output,
+    render_batch,
+)
 from src.cli.utils import ConfigManager, resolve_swarm_id, SwarmIdError
 from src.cli.utils.config import ConfigError
 
@@ -294,33 +299,13 @@ def messages_command(
         if unread_ids:
             _run_async(_batch_mark_read(base_url, unread_ids), "mark messages as read")
 
-    if json_flag:
-        payload = {"swarm_id": sid, "count": len(msgs), "messages": msgs}
-        if unread_ids:
-            payload["marked_read"] = len(unread_ids)
-        json_output(console, payload)
-        return
     if not msgs:
         console.print("[yellow]No messages found[/yellow]")
         return
 
-    # Build header with counts
-    header = f"Inbox ({len(msgs)} messages)"
+    # TOON rendering -- the only output format for message listing
+    header_line = f"Inbox ({len(msgs)} messages)"
     if unread_ids:
-        header += f" - {len(unread_ids)} marked as read"
-
-    rows = [
-        (
-            m["message_id"][:12] + "...",
-            m["sender_id"],
-            m["status"],
-            m["received_at"][:19],
-            m.get("content_preview", ""),
-        )
-        for m in msgs
-    ]
-    format_table(
-        console, header,
-        ["ID", "Sender", "Status", "Received", "Content"],
-        rows,
-    )
+        header_line += f" - {len(unread_ids)} marked as read"
+    console.print(f"[dim]{header_line}[/dim]\n")
+    console.print(render_batch(msgs))

--- a/src/cli/output/__init__.py
+++ b/src/cli/output/__init__.py
@@ -2,6 +2,7 @@
 
 from .formatters import format_error, format_success, format_table, format_warning
 from .json_output import json_output
+from .v2_renderer import render_batch, render_message
 
 __all__ = [
     "format_error",
@@ -9,4 +10,6 @@ __all__ = [
     "format_table",
     "format_warning",
     "json_output",
+    "render_batch",
+    "render_message",
 ]

--- a/src/cli/output/v2_renderer.py
+++ b/src/cli/output/v2_renderer.py
@@ -7,7 +7,7 @@ New messages are stored as TOON.  Legacy messages stored as JSON
 import json
 from typing import Any
 
-import toon_format
+import toon
 
 
 def render_message(content_str: str) -> str:
@@ -28,7 +28,7 @@ def render_message(content_str: str) -> str:
         try:
             msg_dict = json.loads(content_str)
             msg_dict = {k: v for k, v in msg_dict.items() if v is not None}
-            return toon_format.encode(msg_dict)
+            return toon.encode(msg_dict)
         except (json.JSONDecodeError, TypeError):
             return content_str
 

--- a/src/cli/output/v2_renderer.py
+++ b/src/cli/output/v2_renderer.py
@@ -1,0 +1,51 @@
+"""Render stored messages in TOON format.
+
+New messages are stored as TOON.  Legacy messages stored as JSON
+(content starting with ``{``) are converted to TOON on the fly.
+"""
+
+import json
+from typing import Any
+
+import toon
+
+
+def render_message(content_str: str) -> str:
+    """Render a stored message.  Content is TOON (or legacy JSON).
+
+    Args:
+        content_str: The raw ``content`` / ``content_preview`` string
+            from the inbox or outbox store.
+
+    Returns:
+        A TOON-formatted string ready for display.
+    """
+    if not content_str:
+        return ""
+
+    if content_str.startswith("{"):
+        # Legacy JSON message -- convert to TOON
+        try:
+            msg_dict = json.loads(content_str)
+            return toon.encode(msg_dict)
+        except (json.JSONDecodeError, TypeError):
+            return content_str
+
+    # Already TOON -- return directly
+    return content_str
+
+
+def render_batch(messages: list[dict[str, Any]]) -> str:
+    """Render multiple inbox messages separated by blank lines.
+
+    Each message dict must contain a ``content_preview`` key whose value
+    is either TOON or legacy JSON.  The rendered TOON is printed as-is.
+
+    Args:
+        messages: List of message dicts from the ``/api/inbox`` response.
+
+    Returns:
+        Multi-line string with all messages, separated by blank lines.
+    """
+    blocks = [render_message(m.get("content_preview", "")) for m in messages]
+    return "\n\n".join(blocks)

--- a/src/cli/output/v2_renderer.py
+++ b/src/cli/output/v2_renderer.py
@@ -24,9 +24,10 @@ def render_message(content_str: str) -> str:
         return ""
 
     if content_str.startswith("{"):
-        # Legacy JSON message -- convert to TOON
+        # Legacy JSON message -- convert to TOON, strip null fields
         try:
             msg_dict = json.loads(content_str)
+            msg_dict = {k: v for k, v in msg_dict.items() if v is not None}
             return toon.encode(msg_dict)
         except (json.JSONDecodeError, TypeError):
             return content_str

--- a/src/cli/output/v2_renderer.py
+++ b/src/cli/output/v2_renderer.py
@@ -7,7 +7,7 @@ New messages are stored as TOON.  Legacy messages stored as JSON
 import json
 from typing import Any
 
-import toon
+import toon_format
 
 
 def render_message(content_str: str) -> str:
@@ -28,7 +28,7 @@ def render_message(content_str: str) -> str:
         try:
             msg_dict = json.loads(content_str)
             msg_dict = {k: v for k, v in msg_dict.items() if v is not None}
-            return toon.encode(msg_dict)
+            return toon_format.encode(msg_dict)
         except (json.JSONDecodeError, TypeError):
             return content_str
 

--- a/src/server/routes/message.py
+++ b/src/server/routes/message.py
@@ -4,7 +4,7 @@ import sqlite3
 from datetime import datetime, timezone
 from typing import Optional
 
-import toon_format
+import toon
 from fastapi import APIRouter, Request, status
 
 from src.server.models.requests import MessageRequest
@@ -39,7 +39,7 @@ def create_message_router(db: DatabaseManager) -> APIRouter:
         whether to WAKE, QUEUE, or SKIP the message.
         """
         msg_dict = body.model_dump(exclude_none=True)
-        toon_content = toon_format.encode(msg_dict)
+        toon_content = toon.encode(msg_dict)
 
         inbox_msg = InboxMessage(
             message_id=body.message_id,

--- a/src/server/routes/message.py
+++ b/src/server/routes/message.py
@@ -4,6 +4,7 @@ import sqlite3
 from datetime import datetime, timezone
 from typing import Optional
 
+import toon
 from fastapi import APIRouter, Request, status
 
 from src.server.models.requests import MessageRequest
@@ -37,13 +38,16 @@ def create_message_router(db: DatabaseManager) -> APIRouter:
         After persistence, the wake trigger (if configured) evaluates
         whether to WAKE, QUEUE, or SKIP the message.
         """
+        msg_dict = body.model_dump(exclude_none=True)
+        toon_content = toon.encode(msg_dict)
+
         inbox_msg = InboxMessage(
             message_id=body.message_id,
             swarm_id=body.swarm_id,
             sender_id=body.sender.agent_id,
             recipient_id=body.recipient,
             message_type=body.type,
-            content=body.model_dump_json(),
+            content=toon_content,
             received_at=datetime.now(timezone.utc),
             status=InboxStatus.UNREAD,
         )

--- a/src/server/routes/message.py
+++ b/src/server/routes/message.py
@@ -4,7 +4,7 @@ import sqlite3
 from datetime import datetime, timezone
 from typing import Optional
 
-import toon
+import toon_format
 from fastapi import APIRouter, Request, status
 
 from src.server.models.requests import MessageRequest
@@ -39,7 +39,7 @@ def create_message_router(db: DatabaseManager) -> APIRouter:
         whether to WAKE, QUEUE, or SKIP the message.
         """
         msg_dict = body.model_dump(exclude_none=True)
-        toon_content = toon.encode(msg_dict)
+        toon_content = toon_format.encode(msg_dict)
 
         inbox_msg = InboxMessage(
             message_id=body.message_id,

--- a/tests/cli/test_messages.py
+++ b/tests/cli/test_messages.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest.mock import AsyncMock, patch
 
-import toon_format
+import toon
 from typer.testing import CliRunner
 
 from src.cli.main import app
@@ -40,7 +40,7 @@ def _init_agent(monkeypatch, config_dir: Path) -> None:
 
 def _sample_message(status: str = "unread") -> dict:
     """Return a sample inbox message dict with TOON content_preview."""
-    toon_content = toon_format.encode({
+    toon_content = toon.encode({
         "sender": {"agent_id": "sender-agent"},
         "recipient": "test-agent",
         "type": "chat",

--- a/tests/cli/test_messages.py
+++ b/tests/cli/test_messages.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest.mock import AsyncMock, patch
 
-import toon
+import toon_format
 from typer.testing import CliRunner
 
 from src.cli.main import app
@@ -40,7 +40,7 @@ def _init_agent(monkeypatch, config_dir: Path) -> None:
 
 def _sample_message(status: str = "unread") -> dict:
     """Return a sample inbox message dict with TOON content_preview."""
-    toon_content = toon.encode({
+    toon_content = toon_format.encode({
         "sender": {"agent_id": "sender-agent"},
         "recipient": "test-agent",
         "type": "chat",

--- a/tests/cli/test_messages.py
+++ b/tests/cli/test_messages.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest.mock import AsyncMock, patch
 
-import pytest
+import toon
 from typer.testing import CliRunner
 
 from src.cli.main import app
@@ -39,7 +39,13 @@ def _init_agent(monkeypatch, config_dir: Path) -> None:
 
 
 def _sample_message(status: str = "unread") -> dict:
-    """Return a sample inbox message dict."""
+    """Return a sample inbox message dict with TOON content_preview."""
+    toon_content = toon.encode({
+        "sender": {"agent_id": "sender-agent"},
+        "recipient": "test-agent",
+        "type": "chat",
+        "content": "Hello from test",
+    })
     return {
         "message_id": MSG_ID,
         "swarm_id": SWARM_ID,
@@ -47,7 +53,7 @@ def _sample_message(status: str = "unread") -> dict:
         "message_type": "chat",
         "status": status,
         "received_at": "2026-02-09T12:00:00+00:00",
-        "content_preview": "Hello from test",
+        "content_preview": toon_content,
     }
 
 
@@ -282,8 +288,8 @@ class TestMessagesList:
     @patch("src.cli.commands.messages._batch_mark_read", new_callable=AsyncMock)
     @patch("src.cli.commands.messages._fetch_inbox", new_callable=AsyncMock)
     @patch("src.cli.commands.messages._load_base_url", return_value=BASE_URL)
-    def test_list_displays_table(self, mock_url, mock_fetch, mock_batch, monkeypatch):
-        """Message list displays table with inbox header."""
+    def test_list_displays_toon(self, mock_url, mock_fetch, mock_batch, monkeypatch):
+        """Message list displays TOON format with inbox header."""
         mock_fetch.return_value = {"count": 1, "messages": [_sample_message()]}
         mock_batch.return_value = {"action": "read", "updated": 1, "total": 1}
 
@@ -296,12 +302,13 @@ class TestMessagesList:
         assert result.exit_code == 0
         assert "sender-agent" in result.stdout
         assert "Inbox" in result.stdout
+        assert "Hello from test" in result.stdout
 
     @patch("src.cli.commands.messages._batch_mark_read", new_callable=AsyncMock)
     @patch("src.cli.commands.messages._fetch_inbox", new_callable=AsyncMock)
     @patch("src.cli.commands.messages._load_base_url", return_value=BASE_URL)
-    def test_list_json_output(self, mock_url, mock_fetch, mock_batch, monkeypatch):
-        """Message list with --json includes marked_read count."""
+    def test_list_json_flag_ignored(self, mock_url, mock_fetch, mock_batch, monkeypatch):
+        """--json flag in list mode still produces TOON output (JSON only for --count)."""
         mock_fetch.return_value = {"count": 1, "messages": [_sample_message()]}
         mock_batch.return_value = {"action": "read", "updated": 1, "total": 1}
 
@@ -314,30 +321,9 @@ class TestMessagesList:
             )
 
         assert result.exit_code == 0
-        data = json.loads(result.stdout)
-        assert data["swarm_id"] == SWARM_ID
-        assert data["count"] == 1
-        assert data["marked_read"] == 1
-        assert len(data["messages"]) == 1
-
-    @patch("src.cli.commands.messages._batch_mark_read", new_callable=AsyncMock)
-    @patch("src.cli.commands.messages._fetch_inbox", new_callable=AsyncMock)
-    @patch("src.cli.commands.messages._load_base_url", return_value=BASE_URL)
-    def test_list_json_no_mark_read(self, mock_url, mock_fetch, mock_batch, monkeypatch):
-        """JSON output with --no-mark-read omits marked_read field."""
-        mock_fetch.return_value = {"count": 1, "messages": [_sample_message()]}
-
-        with TemporaryDirectory() as tmpdir:
-            config_dir = Path(tmpdir) / "swarm"
-            _init_agent(monkeypatch, config_dir)
-
-            result = runner.invoke(
-                app, ["messages", "-s", SWARM_ID, "--json", "--no-mark-read"],
-            )
-
-        assert result.exit_code == 0
-        data = json.loads(result.stdout)
-        assert "marked_read" not in data
+        # TOON format, not JSON -- --json does not apply to list mode
+        assert "sender-agent" in result.stdout
+        assert "Inbox" in result.stdout
 
 
 # ---------------------------------------------------------------------------

--- a/tests/cli/test_v2_renderer.py
+++ b/tests/cli/test_v2_renderer.py
@@ -11,7 +11,7 @@ Covers:
 
 import json
 
-import toon_format
+import toon
 
 from src.cli.output.v2_renderer import render_batch, render_message
 
@@ -41,7 +41,7 @@ def _toon_message(**overrides: object) -> str:
         "signature": "Rk9PQkFSbase64sig==",
     }
     msg.update(overrides)
-    return toon_format.encode(msg)
+    return toon.encode(msg)
 
 
 def _json_message(**overrides: object) -> str:
@@ -86,7 +86,7 @@ class TestRenderMessageToon:
         assert "Hello from test" in result
 
     def test_simple_toon_object(self):
-        content = toon_format.encode({"name": "Alice", "status": "active"})
+        content = toon.encode({"name": "Alice", "status": "active"})
         result = render_message(content)
         assert result == content
         assert "name: Alice" in result
@@ -115,7 +115,7 @@ class TestRenderMessageLegacyJson:
         original = {"from": "sage", "to": "nexus", "content": "test"}
         json_str = json.dumps(original)
         result = render_message(json_str)
-        decoded = toon_format.decode(result)
+        decoded = toon.decode(result)
         assert decoded == original
 
     def test_malformed_json_returns_raw(self):
@@ -164,14 +164,14 @@ class TestRenderMessageSpecialChars:
     def test_quotes_in_content(self):
         toon_str = _toon_message(content='He said "hello"')
         result = render_message(toon_str)
-        decoded = toon_format.decode(result)
+        decoded = toon.decode(result)
         assert decoded["content"] == 'He said "hello"'
 
     def test_newlines_in_json_content(self):
         json_str = _json_message(content="line1\nline2\nline3")
         result = render_message(json_str)
         assert not result.startswith("{")
-        decoded = toon_format.decode(result)
+        decoded = toon.decode(result)
         assert decoded["content"] == "line1\nline2\nline3"
 
     def test_unicode_in_content(self):
@@ -183,7 +183,7 @@ class TestRenderMessageSpecialChars:
     def test_backslashes_in_json_content(self):
         json_str = _json_message(content="path\\to\\file")
         result = render_message(json_str)
-        decoded = toon_format.decode(result)
+        decoded = toon.decode(result)
         assert decoded["content"] == "path\\to\\file"
 
 
@@ -198,14 +198,14 @@ class TestRenderMessageNestedSections:
     def test_nested_sender_object(self):
         toon_str = _toon_message()
         result = render_message(toon_str)
-        decoded = toon_format.decode(result)
+        decoded = toon.decode(result)
         assert decoded["sender"]["agent_id"] == "finml-sage"
         assert decoded["sender"]["endpoint"] == "https://sage.marbell.com/swarm"
 
     def test_json_with_nested_converts(self):
         json_str = _json_message()
         result = render_message(json_str)
-        decoded = toon_format.decode(result)
+        decoded = toon.decode(result)
         assert isinstance(decoded["sender"], dict)
         assert decoded["sender"]["agent_id"] == "finml-sage"
 

--- a/tests/cli/test_v2_renderer.py
+++ b/tests/cli/test_v2_renderer.py
@@ -11,7 +11,7 @@ Covers:
 
 import json
 
-import toon
+import toon_format
 
 from src.cli.output.v2_renderer import render_batch, render_message
 
@@ -41,7 +41,7 @@ def _toon_message(**overrides: object) -> str:
         "signature": "Rk9PQkFSbase64sig==",
     }
     msg.update(overrides)
-    return toon.encode(msg)
+    return toon_format.encode(msg)
 
 
 def _json_message(**overrides: object) -> str:
@@ -86,7 +86,7 @@ class TestRenderMessageToon:
         assert "Hello from test" in result
 
     def test_simple_toon_object(self):
-        content = toon.encode({"name": "Alice", "status": "active"})
+        content = toon_format.encode({"name": "Alice", "status": "active"})
         result = render_message(content)
         assert result == content
         assert "name: Alice" in result
@@ -115,7 +115,7 @@ class TestRenderMessageLegacyJson:
         original = {"from": "sage", "to": "nexus", "content": "test"}
         json_str = json.dumps(original)
         result = render_message(json_str)
-        decoded = toon.decode(result)
+        decoded = toon_format.decode(result)
         assert decoded == original
 
     def test_malformed_json_returns_raw(self):
@@ -164,14 +164,14 @@ class TestRenderMessageSpecialChars:
     def test_quotes_in_content(self):
         toon_str = _toon_message(content='He said "hello"')
         result = render_message(toon_str)
-        decoded = toon.decode(result)
+        decoded = toon_format.decode(result)
         assert decoded["content"] == 'He said "hello"'
 
     def test_newlines_in_json_content(self):
         json_str = _json_message(content="line1\nline2\nline3")
         result = render_message(json_str)
         assert not result.startswith("{")
-        decoded = toon.decode(result)
+        decoded = toon_format.decode(result)
         assert decoded["content"] == "line1\nline2\nline3"
 
     def test_unicode_in_content(self):
@@ -183,7 +183,7 @@ class TestRenderMessageSpecialChars:
     def test_backslashes_in_json_content(self):
         json_str = _json_message(content="path\\to\\file")
         result = render_message(json_str)
-        decoded = toon.decode(result)
+        decoded = toon_format.decode(result)
         assert decoded["content"] == "path\\to\\file"
 
 
@@ -198,14 +198,14 @@ class TestRenderMessageNestedSections:
     def test_nested_sender_object(self):
         toon_str = _toon_message()
         result = render_message(toon_str)
-        decoded = toon.decode(result)
+        decoded = toon_format.decode(result)
         assert decoded["sender"]["agent_id"] == "finml-sage"
         assert decoded["sender"]["endpoint"] == "https://sage.marbell.com/swarm"
 
     def test_json_with_nested_converts(self):
         json_str = _json_message()
         result = render_message(json_str)
-        decoded = toon.decode(result)
+        decoded = toon_format.decode(result)
         assert isinstance(decoded["sender"], dict)
         assert decoded["sender"]["agent_id"] == "finml-sage"
 

--- a/tests/cli/test_v2_renderer.py
+++ b/tests/cli/test_v2_renderer.py
@@ -1,0 +1,258 @@
+"""Tests for TOON-based message renderer.
+
+Covers:
+- TOON messages render as pass-through (already TOON)
+- Legacy JSON messages convert to TOON on display
+- Special characters in content (quotes, newlines, unicode)
+- Empty content
+- Messages with nested body sections
+- Batch rendering
+"""
+
+import json
+
+import toon
+
+from src.cli.output.v2_renderer import render_batch, render_message
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+SWARM_ID = "716a4150-ab9d-4b54-a2a8-f2b7c607c21e"
+MSG_ID = "abc12345-dead-beef-cafe-000000000001"
+
+
+def _toon_message(**overrides: object) -> str:
+    """Return a TOON-encoded message string."""
+    msg: dict[str, object] = {
+        "protocol_version": "0.1.0",
+        "message_id": MSG_ID,
+        "timestamp": "2026-04-13T14:30:00.000Z",
+        "sender": {
+            "agent_id": "finml-sage",
+            "endpoint": "https://sage.marbell.com/swarm",
+        },
+        "recipient": "nexus-marbell",
+        "swarm_id": SWARM_ID,
+        "type": "message",
+        "content": "Hello from test",
+        "signature": "Rk9PQkFSbase64sig==",
+    }
+    msg.update(overrides)
+    return toon.encode(msg)
+
+
+def _json_message(**overrides: object) -> str:
+    """Return a JSON-encoded wire envelope (legacy format)."""
+    envelope: dict[str, object] = {
+        "protocol_version": "0.1.0",
+        "message_id": MSG_ID,
+        "timestamp": "2026-04-13T14:30:00.000Z",
+        "sender": {
+            "agent_id": "finml-sage",
+            "endpoint": "https://sage.marbell.com/swarm",
+        },
+        "recipient": "nexus-marbell",
+        "swarm_id": SWARM_ID,
+        "type": "message",
+        "content": "Hello from test",
+        "signature": "Rk9PQkFSbase64sig==",
+    }
+    envelope.update(overrides)
+    return json.dumps(envelope)
+
+
+# ---------------------------------------------------------------------------
+# render_message — TOON pass-through
+# ---------------------------------------------------------------------------
+
+
+class TestRenderMessageToon:
+    """TOON content passes through without transformation."""
+
+    def test_toon_passes_through(self):
+        toon_str = _toon_message()
+        result = render_message(toon_str)
+        assert result == toon_str
+
+    def test_toon_preserves_all_fields(self):
+        toon_str = _toon_message()
+        result = render_message(toon_str)
+        assert "finml-sage" in result
+        assert "nexus-marbell" in result
+        assert SWARM_ID in result
+        assert "Hello from test" in result
+
+    def test_simple_toon_object(self):
+        content = toon.encode({"name": "Alice", "status": "active"})
+        result = render_message(content)
+        assert result == content
+        assert "name: Alice" in result
+        assert "status: active" in result
+
+
+# ---------------------------------------------------------------------------
+# render_message — legacy JSON conversion
+# ---------------------------------------------------------------------------
+
+
+class TestRenderMessageLegacyJson:
+    """Legacy JSON messages (starting with '{') convert to TOON."""
+
+    def test_json_converts_to_toon(self):
+        json_str = _json_message()
+        result = render_message(json_str)
+        # Result should NOT start with { (it's TOON now)
+        assert not result.startswith("{")
+        # Should contain the fields in TOON format
+        assert "finml-sage" in result
+        assert "nexus-marbell" in result
+        assert "Hello from test" in result
+
+    def test_json_round_trips_correctly(self):
+        original = {"from": "sage", "to": "nexus", "content": "test"}
+        json_str = json.dumps(original)
+        result = render_message(json_str)
+        decoded = toon.decode(result)
+        assert decoded == original
+
+    def test_malformed_json_returns_raw(self):
+        raw = "{broken json content"
+        result = render_message(raw)
+        assert result == raw
+
+    def test_json_array_returns_raw(self):
+        """A JSON array starting with '[' is not legacy JSON envelope."""
+        raw = "[1, 2, 3]"
+        result = render_message(raw)
+        # Not starting with '{', so treated as already-TOON
+        assert result == raw
+
+
+# ---------------------------------------------------------------------------
+# render_message — empty and edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestRenderMessageEdgeCases:
+    """Edge cases for render_message."""
+
+    def test_empty_string(self):
+        assert render_message("") == ""
+
+    def test_none_like_empty(self):
+        """Empty string produces empty output."""
+        result = render_message("")
+        assert result == ""
+
+    def test_plain_text(self):
+        """Plain text that is not JSON passes through."""
+        result = render_message("just some plain text")
+        assert result == "just some plain text"
+
+
+# ---------------------------------------------------------------------------
+# render_message — special characters
+# ---------------------------------------------------------------------------
+
+
+class TestRenderMessageSpecialChars:
+    """Special characters survive TOON encoding."""
+
+    def test_quotes_in_content(self):
+        toon_str = _toon_message(content='He said "hello"')
+        result = render_message(toon_str)
+        decoded = toon.decode(result)
+        assert decoded["content"] == 'He said "hello"'
+
+    def test_newlines_in_json_content(self):
+        json_str = _json_message(content="line1\nline2\nline3")
+        result = render_message(json_str)
+        assert not result.startswith("{")
+        decoded = toon.decode(result)
+        assert decoded["content"] == "line1\nline2\nline3"
+
+    def test_unicode_in_content(self):
+        toon_str = _toon_message(content="Unicode: \u00e9\u00e8\u00ea \u2603")
+        result = render_message(toon_str)
+        assert "\u00e9\u00e8\u00ea" in result
+        assert "\u2603" in result
+
+    def test_backslashes_in_json_content(self):
+        json_str = _json_message(content="path\\to\\file")
+        result = render_message(json_str)
+        decoded = toon.decode(result)
+        assert decoded["content"] == "path\\to\\file"
+
+
+# ---------------------------------------------------------------------------
+# render_message — nested body sections
+# ---------------------------------------------------------------------------
+
+
+class TestRenderMessageNestedSections:
+    """Messages with nested structures render correctly in TOON."""
+
+    def test_nested_sender_object(self):
+        toon_str = _toon_message()
+        result = render_message(toon_str)
+        decoded = toon.decode(result)
+        assert decoded["sender"]["agent_id"] == "finml-sage"
+        assert decoded["sender"]["endpoint"] == "https://sage.marbell.com/swarm"
+
+    def test_json_with_nested_converts(self):
+        json_str = _json_message()
+        result = render_message(json_str)
+        decoded = toon.decode(result)
+        assert isinstance(decoded["sender"], dict)
+        assert decoded["sender"]["agent_id"] == "finml-sage"
+
+
+# ---------------------------------------------------------------------------
+# render_batch
+# ---------------------------------------------------------------------------
+
+
+class TestRenderBatch:
+    """Tests for batch rendering of multiple messages."""
+
+    def test_batch_separates_with_blank_line(self):
+        msgs = [
+            {"content_preview": _toon_message()},
+            {"content_preview": _toon_message(message_id="msg-2")},
+        ]
+        result = render_batch(msgs)
+        blocks = result.split("\n\n")
+        assert len(blocks) == 2
+
+    def test_batch_single_message(self):
+        msgs = [{"content_preview": _toon_message()}]
+        result = render_batch(msgs)
+        assert "finml-sage" in result
+
+    def test_batch_empty_list(self):
+        result = render_batch([])
+        assert result == ""
+
+    def test_batch_mixed_toon_and_json(self):
+        """Batch handles mix of TOON and legacy JSON messages."""
+        msgs = [
+            {"content_preview": _toon_message()},
+            {"content_preview": _json_message(content="legacy message")},
+        ]
+        result = render_batch(msgs)
+        blocks = result.split("\n\n")
+        assert len(blocks) == 2
+        # First block is TOON pass-through
+        assert not blocks[0].startswith("{")
+        # Second block was JSON, now converted to TOON
+        assert not blocks[1].startswith("{")
+        assert "legacy message" in blocks[1]
+
+    def test_batch_missing_content_preview(self):
+        """Message without content_preview renders as empty."""
+        msgs = [{"message_id": "no-preview"}]
+        result = render_batch(msgs)
+        assert result == ""

--- a/tests/test_message_persistence.py
+++ b/tests/test_message_persistence.py
@@ -1,9 +1,8 @@
 """Integration tests: messages received via HTTP are persisted to inbox."""
 import asyncio
-import json
 from pathlib import Path
 
-import pytest
+import toon
 from fastapi.testclient import TestClient
 
 from src.server.app import create_app
@@ -85,8 +84,8 @@ class TestMessagePersistence:
             assert stored.message_type == msg["type"]
             assert stored.status == InboxStatus.UNREAD
             assert stored.recipient_id == msg["recipient"]
-            # content stores the full JSON payload
-            payload = json.loads(stored.content)
+            # content stores the full TOON payload
+            payload = toon.decode(stored.content)
             assert payload["content"] == "Hello from integration test"
             assert payload["signature"] == msg["signature"]
             await db.close()

--- a/tests/test_message_persistence.py
+++ b/tests/test_message_persistence.py
@@ -2,7 +2,7 @@
 import asyncio
 from pathlib import Path
 
-import toon
+import toon_format
 from fastapi.testclient import TestClient
 
 from src.server.app import create_app
@@ -85,7 +85,7 @@ class TestMessagePersistence:
             assert stored.status == InboxStatus.UNREAD
             assert stored.recipient_id == msg["recipient"]
             # content stores the full TOON payload
-            payload = toon.decode(stored.content)
+            payload = toon_format.decode(stored.content)
             assert payload["content"] == "Hello from integration test"
             assert payload["signature"] == msg["signature"]
             await db.close()

--- a/tests/test_message_persistence.py
+++ b/tests/test_message_persistence.py
@@ -2,7 +2,7 @@
 import asyncio
 from pathlib import Path
 
-import toon_format
+import toon
 from fastapi.testclient import TestClient
 
 from src.server.app import create_app
@@ -85,7 +85,7 @@ class TestMessagePersistence:
             assert stored.status == InboxStatus.UNREAD
             assert stored.recipient_id == msg["recipient"]
             # content stores the full TOON payload
-            payload = toon_format.decode(stored.content)
+            payload = toon.decode(stored.content)
             assert payload["content"] == "Hello from integration test"
             assert payload["signature"] == msg["signature"]
             await db.close()


### PR DESCRIPTION
## Summary

- Server stores messages as TOON (`toon_format.encode()`) instead of JSON (`model_dump_json()`), eliminating the double-encoding problem that broke `--json` parsing
- CLI reads TOON directly — no JSON in the message read path. Legacy JSON messages converted to TOON at read time (first-char `{` detection, null fields stripped)
- TOON is the only output format for message listing — no `--format` flag, no `--json` for list mode
- Official `toon_format` library (v0.9.0-beta.1) from toon-format/toon-python — installed from GitHub (PyPI stub is non-functional)
- 498 tests pass, 21 new renderer tests

## Why TOON

JSON was burning tokens on rich formatting (pretty tables) and breaking on special characters (double-encoded `content_preview`). TOON gives 30-60% token reduction with robust parsing — no regex, no escaping nightmares.

## What changed

| File | Change |
|------|--------|
| `pyproject.toml` | Added `toon_format` from GitHub |
| `src/server/routes/message.py` | `toon_format.encode(msg_dict)` replaces `body.model_dump_json()` |
| `src/cli/output/v2_renderer.py` | New — TOON renderer with legacy JSON fallback + null stripping |
| `src/cli/output/__init__.py` | Export `render_message`, `render_batch` |
| `src/cli/commands/messages.py` | TOON-only list output, removed format branching |
| `tests/cli/test_v2_renderer.py` | 21 tests for TOON rendering |
| `tests/cli/test_messages.py` | Updated for TOON output |
| `tests/test_message_persistence.py` | `toon_format.decode()` replaces `json.loads()` |
| `docs/message-format-v2.md` | Format specification |

## Deployment

```bash
# Pull the branch
git fetch origin && git checkout feat/message-format-v2

# Reinstall via pipx (picks up toon_format dependency)
pipx install -e . --force

# Validate
swarm messages --status all --limit 1
```

## Test plan

- [x] TOON round-trip: encode → decode → assert equal
- [x] Legacy JSON conversion: `{...}` content → TOON on display
- [x] Special characters: quotes, backslashes, newlines, unicode
- [x] Live validation: Nexus + Kelvin nodes operational
- [x] Full test suite: 498 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)