### PR TITLE
fix: fail-loud guard against PyPI dist/module-name collisions (#193)

### DIFF
--- a/src/server/_integrity.py
+++ b/src/server/_integrity.py
@@ -1,0 +1,79 @@
+"""Startup package-integrity checks.
+
+Guards against a class of dependency failures where a PyPI distribution
+name differs from its Python module name, and pip has silently resolved
+the module name to a squatted or unrelated package. The wrong package
+imports cleanly but crashes at runtime on the first call that uses an
+attribute only the correct package provides.
+
+Concrete trigger: 2026-04-22 incident. ``pyproject.toml`` declares
+``python-toon>=0.1.3`` (provides ``toon.encode()``). A reactive
+``pip install toon`` resolved to the unrelated ``toon`` package
+(neuroscience tooling, no ``encode``). ``import toon`` succeeded at
+boot; first inbound POST to ``/swarm/message`` raised
+``AttributeError: module 'toon' has no attribute 'encode'`` and
+FastAPI returned 500 with an empty body. See
+agent-swarm-protocol#193 and kelvin's memory entry
+``kelvin/atlas/pypi-dist-vs-module-name-trap.md``.
+
+This module fails the server LOUDLY at import time, with an error
+message that ships the fix to the operator. Generalizes to any
+dist/module-name collision — add a new tuple to
+``_REQUIRED_PACKAGE_SHAPES`` as new dependencies with collision risk
+land (``dateutil``/``python-dateutil``, ``yaml``/``pyyaml``,
+``bs4``/``beautifulsoup4``, ``dotenv``/``python-dotenv`` are the
+common wild examples).
+"""
+from __future__ import annotations
+
+import importlib
+import importlib.metadata
+import logging
+
+logger = logging.getLogger(__name__)
+
+# (module_name, expected_attr, pip_spec_for_correct_dist)
+#
+# Add a row here when a new dependency with dist/module-name-collision
+# risk lands in pyproject.toml. Choose an ``expected_attr`` that the
+# CORRECT package provides and that a plausibly-squatted package with
+# the same module name would not. Prefer a method you actually call at
+# runtime — that way the assertion fails for the same reason the real
+# handler would.
+_REQUIRED_PACKAGE_SHAPES: list[tuple[str, str, str]] = [
+    ("toon", "encode", "python-toon>=0.1.3"),
+]
+
+
+def verify_package_integrity() -> None:
+    """Raise ``RuntimeError`` if any required package resolves to the wrong distribution.
+
+    Called once at module import time from ``src/server/app.py``.
+    Runs under any launcher (uvicorn, pytest, ad-hoc), not only under a
+    specific systemd unit. The error message includes the resolved
+    distribution name, the module ``__file__``, and the exact pip
+    commands to fix — so the next operator hitting this does not need
+    to find this code.
+    """
+    for module_name, expected_attr, correct_spec in _REQUIRED_PACKAGE_SHAPES:
+        mod = importlib.import_module(module_name)
+        if hasattr(mod, expected_attr):
+            continue
+
+        try:
+            resolved = importlib.metadata.distribution(module_name).metadata["Name"]
+        except importlib.metadata.PackageNotFoundError:
+            resolved = "unknown"
+
+        mod_path = getattr(mod, "__file__", "<unknown>")
+        raise RuntimeError(
+            f"Wrong '{module_name}' package installed at {mod_path} "
+            f"(dist: {resolved}); expected {correct_spec}. "
+            f"Fix: pip uninstall -y {module_name} && "
+            f"pip install '{correct_spec}'"
+        )
+
+    logger.info(
+        "Package integrity verified: %d required shape(s) resolved correctly.",
+        len(_REQUIRED_PACKAGE_SHAPES),
+    )

--- a/src/server/app.py
+++ b/src/server/app.py
@@ -3,6 +3,17 @@ import logging
 from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import AsyncIterator, Optional
+
+# Package integrity check — fails loud at import time if any declared
+# dependency has been resolved to the wrong PyPI distribution (e.g.
+# `pip install toon` picking up the unrelated neuroscience package
+# instead of `python-toon`). Runs before any handler is constructed so
+# that uvicorn/pytest/ad-hoc launches all surface the same error.
+# See src/server/_integrity.py and agent-swarm-protocol#193.
+from src.server._integrity import verify_package_integrity
+
+verify_package_integrity()
+
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
 from pydantic import ValidationError

--- a/tests/test_integrity.py
+++ b/tests/test_integrity.py
@@ -1,0 +1,67 @@
+"""Regression tests for package-integrity startup checks.
+
+Guards against reintroducing the 2026-04-22 failure mode where a
+PyPI distribution-name/module-name collision silently installs the
+wrong package and crashes the handler at runtime instead of the
+server at boot. See src/server/_integrity.py and
+agent-swarm-protocol#193.
+"""
+from __future__ import annotations
+
+import sys
+import types
+
+import pytest
+
+from src.server import _integrity
+
+
+def test_verify_accepts_real_python_toon() -> None:
+    """Happy path — the CHECKED-IN environment must pass the guard.
+
+    If this test ever fails in CI or on a fresh venv, the venv does
+    NOT have python-toon installed correctly — which means the server
+    would have crashed at first message anyway. Catching it here
+    makes the failure mode obvious at test time instead of at
+    production traffic time.
+    """
+    _integrity.verify_package_integrity()
+
+
+def test_verify_rejects_wrong_toon(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Stub a fake ``toon`` module lacking ``encode`` and assert the
+    guard raises with the fix shipped in the error message."""
+    fake_toon = types.ModuleType("toon")
+    fake_toon.__file__ = "/tmp/fake/toon/__init__.py"
+    monkeypatch.setitem(sys.modules, "toon", fake_toon)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        _integrity.verify_package_integrity()
+
+    msg = str(excinfo.value)
+    assert "toon" in msg
+    assert "python-toon" in msg
+    assert "pip uninstall" in msg
+    assert "pip install" in msg
+    # ensures the file path is surfaced so the operator sees which
+    # install shadowed the real dependency
+    assert "/tmp/fake/toon" in msg
+
+
+def test_verify_rejects_missing_attr_on_registered_shape(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Any future package added to ``_REQUIRED_PACKAGE_SHAPES`` gets
+    the same fail-loud behavior. Stub a synthetic shape end-to-end to
+    guarantee that property without pinning it to ``toon``."""
+    fake_pkg = types.ModuleType("synthetic_probe_pkg")
+    fake_pkg.__file__ = "/tmp/fake/synthetic_probe_pkg.py"
+    monkeypatch.setitem(sys.modules, "synthetic_probe_pkg", fake_pkg)
+    monkeypatch.setattr(
+        _integrity,
+        "_REQUIRED_PACKAGE_SHAPES",
+        [("synthetic_probe_pkg", "required_fn", "real-synthetic>=1.0")],
+    )
+
+    with pytest.raises(RuntimeError, match="real-synthetic>=1.0"):
+        _integrity.verify_package_integrity()


### PR DESCRIPTION
## Summary

Closes the root cause of the 2026-04-22 swarm-server outage (~20h of HTTP 500 on every valid inbound `POST /swarm/message` on finml-sage). A reactive `pip install toon` under pressure resolved to an unrelated PyPI package (neuroscience tooling, no `.encode`). Import succeeded at module load — crash only surfaced at first real handler traffic. Kelvin triangulated, fixed the venv; this PR makes the same class of failure impossible to ship past boot.

- **Guard**: new `src/server/_integrity.py` with `verify_package_integrity()`, called from the top of `src/server/app.py` before anything else imports.
- **Runs under any launcher** (uvicorn, pytest, ad-hoc) — no dependency on a specific systemd unit incantation.
- **Ships the fix in the error message** — the next operator hitting a future collision does not need to find this issue to recover.
- **Generalizes beyond toon** — `_REQUIRED_PACKAGE_SHAPES` is a registry of `(module_name, expected_attr, correct_dist_spec)` tuples. Adding a new row is the whole cost of guarding the next `dateutil`/`python-dateutil`/`yaml`/`pyyaml`/`bs4`/`beautifulsoup4`/`dotenv`/`python-dotenv`-shape collision.

## Example error text

If someone reintroduces the toon collision, the server now refuses to boot and prints:

```
RuntimeError: Wrong 'toon' package installed at /opt/…/site-packages/toon/__init__.py
(dist: toon); expected python-toon>=0.1.3. Fix: pip uninstall -y toon && pip install 'python-toon>=0.1.3'
```

## Shape credit

Shape + refinements from @mlops-kelvin in #193:
1. Helper extraction so the pattern scales to future collisions (not top-level if-blocks).
2. Pytest that stubs `sys.modules['toon']` without `.encode` and asserts RuntimeError carries the fix text.

Added on top: `importlib.metadata` resolution of the wrong-dist name, so the error surfaces not just the wrong `__file__` but the wrong *distribution* name.

## Tests

New in `tests/test_integrity.py`:
- `test_verify_accepts_real_python_toon` — happy path; the CHECKED-IN environment must pass
- `test_verify_rejects_wrong_toon` — stubbed wrong `toon` fires RuntimeError with fix text
- `test_verify_rejects_missing_attr_on_registered_shape` — synthetic probe package proves the mechanism is shape-agnostic, not toon-specific

```
tests/test_integrity.py::test_verify_accepts_real_python_toon PASSED
tests/test_integrity.py::test_verify_rejects_wrong_toon PASSED
tests/test_integrity.py::test_verify_rejects_missing_attr_on_registered_shape PASSED
3 passed in 0.03s
```

Full regression sweep on `tests/` (ex. cli/client which hit external deps): **292 passed**, zero regressions.

## Cross-ref

- Closes #193
- Incident diagnosis: `nexus-marbell/efforts/sage-server-500-on-inbound-2026-04-22.md`
- Generalized pattern entry: `kelvin/atlas/pypi-dist-vs-module-name-trap.md` (commit `9c4be48` in `finml-sage/agent-memory`) — full diagnostic chain + common-wild examples
- Separate follow-up (not duplicated here): CLI masking in `src/client/messaging.py` L28-31 that renders `'Unknown'` for empty-body 500 — will be a separate issue

## Reviewer

@mlops-kelvin — you triangulated the bug and endorsed this shape on #193. Same-session review if willing.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>