### PR TITLE
fix: receiver-side swarm_members sync on system events (#197)

### DIFF
--- a/src/server/app.py
+++ b/src/server/app.py
@@ -106,7 +106,7 @@ def create_app(config: Optional[ServerConfig] = None) -> FastAPI:
     app.add_middleware(RequestLoggingMiddleware)
     app.add_middleware(RateLimitMiddleware, requests_per_minute=config.rate_limit.messages_per_minute)
     app.add_exception_handler(ValidationError, _validation_error_handler)
-    app.include_router(create_message_router(db_manager))
+    app.include_router(create_message_router(db_manager, config.agent.agent_id))
     app.include_router(create_join_router(config, db_manager))
     app.include_router(create_health_router(config))
     app.include_router(create_info_router(config))

--- a/src/server/routes/message.py
+++ b/src/server/routes/message.py
@@ -9,6 +9,7 @@ from fastapi import APIRouter, Request, status
 
 from src.server.models.requests import MessageRequest
 from src.server.models.responses import MessageQueuedResponse
+from src.server.system_dispatch import dispatch_system_message
 from src.state.database import DatabaseManager
 from src.state.models.inbox import InboxMessage, InboxStatus
 from src.state.repositories.inbox import InboxRepository
@@ -17,7 +18,7 @@ from src.claude.wake_trigger import WakeTrigger
 logger = logging.getLogger(__name__)
 
 
-def create_message_router(db: DatabaseManager) -> APIRouter:
+def create_message_router(db: DatabaseManager, local_agent_id: str) -> APIRouter:
     """Create message router with injected dependencies."""
     router = APIRouter()
 
@@ -60,6 +61,20 @@ def create_message_router(db: DatabaseManager) -> APIRouter:
                     "Duplicate message %s ignored (idempotent)",
                     body.message_id,
                 )
+
+        # Receiver-side membership lifecycle dispatch (issue #197). Fire
+        # AFTER inbox persistence so the message is durably recorded even
+        # if the dispatcher (which may make a network call to /swarm/info)
+        # raises. The dispatcher swallows its own errors but the wrap is
+        # belt-and-suspenders: a system-message side effect must never
+        # prevent message acceptance.
+        try:
+            await dispatch_system_message(db, body, local_agent_id)
+        except Exception as exc:
+            logger.warning(
+                "System dispatch failed for message %s: %s",
+                body.message_id, exc,
+            )
 
         # Fire-and-forget wake trigger evaluation (non-blocking).
         # Catch all exceptions: wake is a side effect that must never

--- a/src/server/system_dispatch.py
+++ b/src/server/system_dispatch.py
@@ -1,0 +1,292 @@
+"""Receiver-side dispatch for system membership lifecycle events.
+
+When a member receives a system message with action=member_joined, member_left,
+or member_kicked, the local swarm_members table must be updated so direct A2A
+sends can route. Without this dispatch, members can only reach a newly-joined
+agent via broadcast — direct sends fail silently on the sender side.
+
+Path 1b from issue #197: lazy-fetch /swarm/info on the new member's endpoint
+to retrieve the public_key, pull swarm_id from the message envelope, and
+INSERT OR IGNORE into swarm_members. INSERT OR REPLACE into public_keys to
+pre-warm the verification cache. Symmetric DELETE for member_left/member_kicked
+on swarm_members only — public_keys cache survives churn.
+
+Network failures fetching /swarm/info are logged and swallowed: the message
+must remain accepted, and the lazy-fetch fallback in the signature verifier
+will populate public_keys on first inbound message from the new member.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+import httpx
+
+from src.server.models.requests import MessageRequest
+from src.state.database import DatabaseManager
+from src.state.models.public_key import PublicKeyEntry
+from src.state.repositories.keys import PublicKeyRepository
+
+logger = logging.getLogger(__name__)
+
+
+# These actions are the receiver-side membership lifecycle events that
+# mutate local swarm_members state. Mute/unmute do not change membership
+# and are deliberately excluded.
+_JOIN_ACTION = "member_joined"
+_LEAVE_ACTIONS = {"member_left", "member_kicked"}
+
+_SWARM_INFO_TIMEOUT_SECONDS = 5.0
+_PROTOCOL_VERSION = "0.1.0"
+
+
+def _parse_action(content: str) -> Optional[dict[str, Any]]:
+    """Return parsed action dict from JSON content, or None on bad input.
+
+    System lifecycle messages carry a JSON object as content with at least
+    an `action` field. Returns None for non-JSON content or content that
+    is not a JSON object — those are not lifecycle events.
+    """
+    try:
+        parsed = json.loads(content)
+    except (ValueError, TypeError):
+        return None
+    if not isinstance(parsed, dict):
+        return None
+    return parsed
+
+
+async def _fetch_public_key(
+    endpoint: str, agent_id: str, local_agent_id: str,
+) -> Optional[str]:
+    """GET <endpoint>/info and return base64 public_key, or None.
+
+    Endpoint convention: the swarm member's endpoint already includes the
+    /swarm prefix (e.g. https://host/swarm), and routes are appended as
+    bare names. Mirrors the join URL pattern in src/client/operations.py
+    (`{endpoint.rstrip('/')}/join`).
+
+    Failures (timeout, non-200, missing field, mismatched agent_id) log and
+    return None. The caller continues without the public_key — the lazy-fetch
+    fallback in the signature verifier will populate the cache later.
+    """
+    url = f"{endpoint.rstrip('/')}/info"
+    headers = {
+        "X-Agent-ID": local_agent_id,
+        "X-Swarm-Protocol": _PROTOCOL_VERSION,
+    }
+    try:
+        async with httpx.AsyncClient(
+            timeout=_SWARM_INFO_TIMEOUT_SECONDS,
+        ) as client:
+            response = await client.get(url, headers=headers)
+    except httpx.HTTPError as exc:
+        logger.warning(
+            "Failed to fetch /swarm/info for new member '%s' at %s: %s",
+            agent_id, endpoint, exc,
+        )
+        return None
+    if response.status_code != 200:
+        logger.warning(
+            "/swarm/info for new member '%s' returned %s",
+            agent_id, response.status_code,
+        )
+        return None
+    try:
+        data = response.json()
+    except ValueError:
+        logger.warning(
+            "/swarm/info for new member '%s' returned non-JSON body",
+            agent_id,
+        )
+        return None
+    if not isinstance(data, dict):
+        logger.warning(
+            "/swarm/info for new member '%s' returned non-object body",
+            agent_id,
+        )
+        return None
+    public_key = data.get("public_key")
+    info_agent_id = data.get("agent_id")
+    if not isinstance(public_key, str) or not public_key:
+        logger.warning(
+            "/swarm/info for '%s' missing or invalid public_key field",
+            agent_id,
+        )
+        return None
+    if info_agent_id != agent_id:
+        logger.warning(
+            "/swarm/info agent_id mismatch: expected '%s', got '%s'",
+            agent_id, info_agent_id,
+        )
+        return None
+    return public_key
+
+
+async def _handle_member_joined(
+    db: DatabaseManager,
+    swarm_id: str,
+    new_agent_id: str,
+    new_endpoint: str,
+    joined_at_iso: str,
+    public_key: str,
+) -> None:
+    """Insert the new member into swarm_members and pre-warm public_keys.
+
+    Idempotent on swarm_members (INSERT OR IGNORE — duplicate broadcasts do
+    not raise and do not clobber existing rows). Pre-warms public_keys with
+    INSERT OR REPLACE — the cache survives churn but the freshest copy wins.
+    """
+    async with db.connection() as conn:
+        await conn.execute(
+            "INSERT OR IGNORE INTO swarm_members "
+            "(agent_id, swarm_id, endpoint, public_key, joined_at) "
+            "VALUES (?, ?, ?, ?, ?)",
+            (new_agent_id, swarm_id, new_endpoint, public_key, joined_at_iso),
+        )
+        await conn.commit()
+        # Pre-warm the public_keys cache via the repository so the
+        # PublicKeyEntry validation runs (HTTPS endpoint check, non-empty
+        # key check) before the row lands.
+        entry = PublicKeyEntry(
+            agent_id=new_agent_id,
+            public_key=public_key,
+            fetched_at=datetime.now(timezone.utc),
+            endpoint=new_endpoint,
+        )
+        await PublicKeyRepository(conn).store(entry)
+    logger.info(
+        "Receiver-side sync: added '%s' to swarm_members for swarm '%s'",
+        new_agent_id, swarm_id,
+    )
+
+
+async def _handle_member_removed(
+    db: DatabaseManager,
+    swarm_id: str,
+    removed_agent_id: str,
+    action: str,
+) -> None:
+    """Remove the agent from swarm_members. public_keys cache survives.
+
+    DELETE only from swarm_members — the public_keys cache is preserved
+    so signature verification of any in-flight messages from the removed
+    agent still works, and a re-join does not require a re-fetch.
+    """
+    async with db.connection() as conn:
+        cursor = await conn.execute(
+            "DELETE FROM swarm_members WHERE agent_id = ? AND swarm_id = ?",
+            (removed_agent_id, swarm_id),
+        )
+        await conn.commit()
+    logger.info(
+        "Receiver-side sync: removed '%s' from swarm_members for swarm "
+        "'%s' on action '%s' (rows=%d)",
+        removed_agent_id, swarm_id, action, cursor.rowcount,
+    )
+
+
+async def dispatch_system_message(
+    db: DatabaseManager,
+    body: MessageRequest,
+    local_agent_id: str,
+) -> None:
+    """Apply receiver-side state mutations for membership lifecycle events.
+
+    Called after the inbox persistence step in the message receive flow.
+    Returns silently for non-system messages, non-membership-lifecycle
+    actions, malformed content, or any internal error — the message must
+    still be accepted regardless of dispatch outcome.
+
+    Args:
+        db: Initialized DatabaseManager.
+        body: The validated MessageRequest just persisted to the inbox.
+        local_agent_id: The receiving agent's own ID, used in the
+            X-Agent-ID header on the /swarm/info fetch.
+    """
+    if body.type != "system":
+        return
+    payload = _parse_action(body.content)
+    if payload is None:
+        return
+    action = payload.get("action")
+    if action != _JOIN_ACTION and action not in _LEAVE_ACTIONS:
+        return
+
+    target_agent_id = payload.get("agent_id")
+    if not isinstance(target_agent_id, str) or not target_agent_id:
+        logger.warning(
+            "System message action '%s' missing agent_id; skipping dispatch",
+            action,
+        )
+        return
+
+    swarm_id = body.swarm_id
+
+    try:
+        if action == _JOIN_ACTION:
+            new_endpoint = payload.get("endpoint")
+            if not isinstance(new_endpoint, str) or not new_endpoint:
+                # The current broadcast payload (built by
+                # build_notification_message in src/server/notifications.py)
+                # does not include endpoint — fall back to the sender's
+                # endpoint from the envelope, which carries the joining
+                # agent's endpoint when the master forwards the broadcast.
+                new_endpoint = body.sender.endpoint
+            if not new_endpoint.startswith("https://"):
+                logger.warning(
+                    "member_joined for '%s': endpoint '%s' is not HTTPS; "
+                    "skipping dispatch",
+                    target_agent_id, new_endpoint,
+                )
+                return
+
+            joined_at_iso = payload.get("joined_at")
+            if not isinstance(joined_at_iso, str) or not joined_at_iso:
+                # Fall back to the message timestamp if joined_at is not
+                # in the payload. The current notifications.py omits
+                # joined_at — the message envelope timestamp is a safe
+                # proxy for "when the receiver became aware of the join".
+                joined_at_iso = body.timestamp
+
+            public_key = await _fetch_public_key(
+                new_endpoint, target_agent_id, local_agent_id,
+            )
+            if public_key is None:
+                # Fail loud (logged), continue silently. The lazy-fetch
+                # in the signature verifier will populate public_keys on
+                # the first inbound message from the new member, and a
+                # subsequent member_joined retry — or a manual swarm
+                # refresh — can complete the swarm_members write later.
+                logger.warning(
+                    "Skipping swarm_members insert for '%s': public_key "
+                    "fetch failed; lazy-fetch will retry on first verify",
+                    target_agent_id,
+                )
+                return
+
+            await _handle_member_joined(
+                db=db,
+                swarm_id=swarm_id,
+                new_agent_id=target_agent_id,
+                new_endpoint=new_endpoint,
+                joined_at_iso=joined_at_iso,
+                public_key=public_key,
+            )
+        else:
+            await _handle_member_removed(
+                db=db,
+                swarm_id=swarm_id,
+                removed_agent_id=target_agent_id,
+                action=action,
+            )
+    except Exception as exc:
+        # Last-resort guard: a dispatch failure must never block message
+        # acceptance. Log loudly so the gap is visible to operators.
+        logger.exception(
+            "Receiver-side dispatch failed for action '%s' agent '%s' "
+            "swarm '%s': %s",
+            action, target_agent_id, swarm_id, exc,
+        )

--- a/tests/test_receiver_member_sync.py
+++ b/tests/test_receiver_member_sync.py
@@ -1,0 +1,515 @@
+"""Tests for receiver-side swarm_members sync on system lifecycle events.
+
+Issue #197: when a member receives a system message with action=member_joined,
+member_left, or member_kicked, the local swarm_members table must be updated
+so direct A2A sends can route. Without this dispatch, members can only reach
+a newly-joined agent via broadcast.
+
+Four cases:
+- happy path: member_joined POST + /swarm/info fetched populates 5+4 cols
+- /swarm/info unreachable: fetch fails, swarm_members unchanged, msg queued
+- idempotent re-receipt: same member_joined twice = exactly one row
+- symmetric leave/kick: deletes from swarm_members, public_keys survives
+"""
+import asyncio
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from fastapi.testclient import TestClient
+
+from src.server.app import create_app
+from src.server.config import (
+    AgentConfig,
+    RateLimitConfig,
+    ServerConfig,
+    WakeConfig,
+    WakeEndpointConfig,
+)
+from src.state.database import DatabaseManager
+from src.state.models.member import SwarmMember, SwarmMembership, SwarmSettings
+from src.state.models.public_key import PublicKeyEntry
+from src.state.repositories.keys import PublicKeyRepository
+from src.state.repositories.membership import MembershipRepository
+
+SWARM_ID = "550e8400-e29b-41d4-a716-446655440000"
+LOCAL_AGENT_ID = "test-agent-001"
+MASTER_AGENT_ID = "master-agent"
+NEW_AGENT_ID = "new-agent"
+NEW_AGENT_ENDPOINT = "https://new.example.com/swarm"
+NEW_AGENT_PUBKEY = "TEbdvaX/2wLtQRodO+9L4XvqDkrvjwTfITNja66wcl4="
+MASTER_ENDPOINT = "https://master.example.com/swarm"
+MASTER_PUBKEY = "bWFzdGVyLWtleS1iYXNlNjQtcGFkZGluZw=="
+LOCAL_ENDPOINT = "https://test.example.com"
+LOCAL_PUBKEY = "dGVzdC1wdWJsaWMta2V5LWJhc2U2NA=="
+
+
+def _seed_swarm(db_path: Path) -> None:
+    """Seed a swarm with master + the local (receiving) agent as members."""
+
+    async def _seed() -> None:
+        db = DatabaseManager(db_path)
+        await db.initialize()
+        master = SwarmMember(
+            agent_id=MASTER_AGENT_ID,
+            endpoint=MASTER_ENDPOINT,
+            public_key=MASTER_PUBKEY,
+            joined_at=datetime.now(timezone.utc),
+        )
+        local = SwarmMember(
+            agent_id=LOCAL_AGENT_ID,
+            endpoint=LOCAL_ENDPOINT,
+            public_key=LOCAL_PUBKEY,
+            joined_at=datetime.now(timezone.utc),
+        )
+        swarm = SwarmMembership(
+            swarm_id=SWARM_ID,
+            name="Test Swarm",
+            master=MASTER_AGENT_ID,
+            members=(master, local),
+            joined_at=datetime.now(timezone.utc),
+            settings=SwarmSettings(
+                allow_member_invite=False, require_approval=False,
+            ),
+        )
+        async with db.connection() as conn:
+            await MembershipRepository(conn).create_swarm(swarm)
+        await db.close()
+
+    asyncio.run(_seed())
+
+
+def _make_config(db_path: Path) -> ServerConfig:
+    return ServerConfig(
+        agent=AgentConfig(
+            agent_id=LOCAL_AGENT_ID,
+            endpoint=LOCAL_ENDPOINT,
+            public_key=LOCAL_PUBKEY,
+            protocol_version="0.1.0",
+            capabilities=("message", "system", "notification"),
+        ),
+        rate_limit=RateLimitConfig(messages_per_minute=600),
+        db_path=db_path,
+        wake=WakeConfig(enabled=False, endpoint=""),
+        wake_endpoint=WakeEndpointConfig(enabled=False),
+    )
+
+
+def _system_message(
+    action: str,
+    target_agent_id: str,
+    *,
+    message_id: str = "00000000-0000-0000-0000-000000000001",
+    sender_endpoint: str = NEW_AGENT_ENDPOINT,
+    sender_id: str = MASTER_AGENT_ID,
+    extra_content: dict | None = None,
+) -> dict:
+    """Build a wire-format system message for the receiver endpoint."""
+    content: dict = {
+        "type": "system",
+        "action": action,
+        "agent_id": target_agent_id,
+        "swarm_id": SWARM_ID,
+    }
+    if extra_content:
+        content.update(extra_content)
+    return {
+        "protocol_version": "0.1.0",
+        "message_id": message_id,
+        "timestamp": "2026-04-27T06:21:32.000Z",
+        "sender": {"agent_id": sender_id, "endpoint": sender_endpoint},
+        "recipient": LOCAL_AGENT_ID,
+        "swarm_id": SWARM_ID,
+        "type": "system",
+        "content": json.dumps(content),
+        "signature": "dGVzdC1zaWduYXR1cmUtYmFzZTY0",
+    }
+
+
+def _build_swarm_info_mock(public_key: str = NEW_AGENT_PUBKEY) -> AsyncMock:
+    """Build an AsyncMock httpx.AsyncClient that returns a /swarm/info response."""
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {
+        "agent_id": NEW_AGENT_ID,
+        "endpoint": NEW_AGENT_ENDPOINT,
+        "public_key": public_key,
+        "protocol_version": "0.1.0",
+        "capabilities": ["message", "system"],
+    }
+    mock_instance = AsyncMock()
+    mock_instance.__aenter__.return_value = mock_instance
+    mock_instance.__aexit__.return_value = None
+    mock_instance.get = AsyncMock(return_value=mock_response)
+    return mock_instance
+
+
+def _row_to_dict(row) -> dict:
+    return {key: row[key] for key in row.keys()}
+
+
+def _read_table(db_path: Path, table: str, where: str = "") -> list[dict]:
+    async def _read() -> list[dict]:
+        db = DatabaseManager(db_path)
+        await db.initialize()
+        async with db.connection() as conn:
+            sql = f"SELECT * FROM {table}"
+            if where:
+                sql = f"{sql} WHERE {where}"
+            cursor = await conn.execute(sql)
+            rows = await cursor.fetchall()
+        await db.close()
+        return [_row_to_dict(r) for r in rows]
+
+    return asyncio.run(_read())
+
+
+class TestMemberJoinedReceiverDispatch:
+    """Receiving member_joined writes swarm_members and pre-warms public_keys."""
+
+    def test_happy_path_writes_swarm_members_and_public_keys(
+        self, tmp_path: Path,
+    ) -> None:
+        """member_joined POST → /swarm/info fetched → 5 cols + cache populated."""
+        db_path = tmp_path / "happy.db"
+        _seed_swarm(db_path)
+        config = _make_config(db_path)
+
+        with patch(
+            "src.server.system_dispatch.httpx.AsyncClient",
+        ) as mock_client_factory:
+            mock_instance = _build_swarm_info_mock()
+            mock_client_factory.return_value = mock_instance
+            with TestClient(create_app(config)) as client:
+                msg = _system_message(
+                    action="member_joined",
+                    target_agent_id=NEW_AGENT_ID,
+                    sender_endpoint=NEW_AGENT_ENDPOINT,
+                    extra_content={
+                        "endpoint": NEW_AGENT_ENDPOINT,
+                        "joined_at": "2026-04-27T06:21:32.000Z",
+                    },
+                )
+                response = client.post(
+                    "/swarm/message",
+                    json=msg,
+                    headers={
+                        "Content-Type": "application/json",
+                        "X-Agent-ID": MASTER_AGENT_ID,
+                        "X-Swarm-Protocol": "0.1.0",
+                    },
+                )
+                assert response.status_code == 200
+                assert response.json()["status"] == "queued"
+
+        # Verify /info URL convention: endpoint already includes /swarm,
+        # so route is appended bare. Compare to client/operations.py
+        # join URL pattern (`{endpoint.rstrip('/')}/join`).
+        mock_instance.get.assert_called_once()
+        call_url = mock_instance.get.call_args[0][0]
+        assert call_url == f"{NEW_AGENT_ENDPOINT}/info", (
+            f"Expected /info appended to swarm endpoint, got: {call_url}"
+        )
+        call_headers = mock_instance.get.call_args.kwargs["headers"]
+        assert call_headers["X-Agent-ID"] == LOCAL_AGENT_ID
+        assert call_headers["X-Swarm-Protocol"] == "0.1.0"
+
+        members = _read_table(
+            db_path, "swarm_members",
+            where=f"agent_id = '{NEW_AGENT_ID}' AND swarm_id = '{SWARM_ID}'",
+        )
+        assert len(members) == 1
+        row = members[0]
+        # All 5 NOT NULL columns present
+        assert row["agent_id"] == NEW_AGENT_ID
+        assert row["swarm_id"] == SWARM_ID
+        assert row["endpoint"] == NEW_AGENT_ENDPOINT
+        assert row["public_key"] == NEW_AGENT_PUBKEY
+        assert row["joined_at"] == "2026-04-27T06:21:32.000Z"
+
+        keys = _read_table(
+            db_path, "public_keys", where=f"agent_id = '{NEW_AGENT_ID}'",
+        )
+        assert len(keys) == 1
+        assert keys[0]["public_key"] == NEW_AGENT_PUBKEY
+        assert keys[0]["endpoint"] == NEW_AGENT_ENDPOINT
+        assert keys[0]["fetched_at"]  # any non-empty ISO timestamp
+
+    def test_swarm_info_unreachable_does_not_crash(
+        self, tmp_path: Path,
+    ) -> None:
+        """When /swarm/info is unreachable, msg stays queued, tables unchanged."""
+        import httpx
+
+        db_path = tmp_path / "unreachable.db"
+        _seed_swarm(db_path)
+        config = _make_config(db_path)
+
+        with patch(
+            "src.server.system_dispatch.httpx.AsyncClient",
+        ) as mock_client_factory:
+            mock_instance = AsyncMock()
+            mock_instance.__aenter__.return_value = mock_instance
+            mock_instance.__aexit__.return_value = None
+            mock_instance.get = AsyncMock(
+                side_effect=httpx.ConnectError("connection refused"),
+            )
+            mock_client_factory.return_value = mock_instance
+            with TestClient(create_app(config)) as client:
+                msg = _system_message(
+                    action="member_joined",
+                    target_agent_id=NEW_AGENT_ID,
+                    sender_endpoint=NEW_AGENT_ENDPOINT,
+                    extra_content={
+                        "endpoint": NEW_AGENT_ENDPOINT,
+                        "joined_at": "2026-04-27T06:21:32.000Z",
+                    },
+                )
+                response = client.post(
+                    "/swarm/message",
+                    json=msg,
+                    headers={
+                        "Content-Type": "application/json",
+                        "X-Agent-ID": MASTER_AGENT_ID,
+                        "X-Swarm-Protocol": "0.1.0",
+                    },
+                )
+                # Message must still be accepted
+                assert response.status_code == 200
+                assert response.json()["status"] == "queued"
+
+        # No row was inserted because the public_key fetch failed
+        members = _read_table(
+            db_path, "swarm_members",
+            where=f"agent_id = '{NEW_AGENT_ID}'",
+        )
+        assert members == []
+        keys = _read_table(
+            db_path, "public_keys", where=f"agent_id = '{NEW_AGENT_ID}'",
+        )
+        assert keys == []
+
+        # And the inbox row exists (message was persisted before dispatch)
+        inbox = _read_table(
+            db_path, "inbox",
+            where=f"sender_id = '{MASTER_AGENT_ID}'",
+        )
+        assert len(inbox) == 1
+
+    def test_idempotent_re_receipt_does_not_duplicate(
+        self, tmp_path: Path,
+    ) -> None:
+        """Receiving the same member_joined twice → exactly one row, no exception."""
+        db_path = tmp_path / "idempotent.db"
+        _seed_swarm(db_path)
+        config = _make_config(db_path)
+
+        with patch(
+            "src.server.system_dispatch.httpx.AsyncClient",
+        ) as mock_client_factory:
+            mock_client_factory.return_value = _build_swarm_info_mock()
+            with TestClient(create_app(config)) as client:
+                msg_id_a = "00000000-0000-0000-0000-00000000aaaa"
+                msg_id_b = "00000000-0000-0000-0000-00000000bbbb"
+                msg_a = _system_message(
+                    action="member_joined",
+                    target_agent_id=NEW_AGENT_ID,
+                    message_id=msg_id_a,
+                    sender_endpoint=NEW_AGENT_ENDPOINT,
+                    extra_content={
+                        "endpoint": NEW_AGENT_ENDPOINT,
+                        "joined_at": "2026-04-27T06:21:32.000Z",
+                    },
+                )
+                msg_b = dict(msg_a)
+                msg_b["message_id"] = msg_id_b
+                # Second receipt has DIFFERENT message_id (so the inbox
+                # idempotency at message level does not deduplicate it)
+                # but identical payload — INSERT OR IGNORE on swarm_members
+                # must still produce exactly one row.
+                resp_a = client.post(
+                    "/swarm/message", json=msg_a,
+                    headers={
+                        "Content-Type": "application/json",
+                        "X-Agent-ID": MASTER_AGENT_ID,
+                        "X-Swarm-Protocol": "0.1.0",
+                    },
+                )
+                resp_b = client.post(
+                    "/swarm/message", json=msg_b,
+                    headers={
+                        "Content-Type": "application/json",
+                        "X-Agent-ID": MASTER_AGENT_ID,
+                        "X-Swarm-Protocol": "0.1.0",
+                    },
+                )
+                assert resp_a.status_code == 200
+                assert resp_b.status_code == 200
+
+        members = _read_table(
+            db_path, "swarm_members",
+            where=f"agent_id = '{NEW_AGENT_ID}' AND swarm_id = '{SWARM_ID}'",
+        )
+        assert len(members) == 1
+
+
+class TestMemberRemovedReceiverDispatch:
+    """Receiving member_left or member_kicked deletes from swarm_members only."""
+
+    def test_member_left_deletes_swarm_members_keeps_public_keys(
+        self, tmp_path: Path,
+    ) -> None:
+        """member_left POST → swarm_members row removed, public_keys cache survives."""
+        db_path = tmp_path / "left.db"
+        _seed_swarm(db_path)
+        config = _make_config(db_path)
+
+        # Pre-populate the new agent into swarm_members AND public_keys
+        # (simulating an earlier successful member_joined receipt).
+        async def _seed_new_member() -> None:
+            db = DatabaseManager(db_path)
+            await db.initialize()
+            async with db.connection() as conn:
+                await conn.execute(
+                    "INSERT INTO swarm_members "
+                    "(agent_id, swarm_id, endpoint, public_key, joined_at) "
+                    "VALUES (?, ?, ?, ?, ?)",
+                    (
+                        NEW_AGENT_ID, SWARM_ID, NEW_AGENT_ENDPOINT,
+                        NEW_AGENT_PUBKEY, "2026-04-27T06:21:32.000Z",
+                    ),
+                )
+                await conn.commit()
+                await PublicKeyRepository(conn).store(PublicKeyEntry(
+                    agent_id=NEW_AGENT_ID,
+                    public_key=NEW_AGENT_PUBKEY,
+                    fetched_at=datetime.now(timezone.utc),
+                    endpoint=NEW_AGENT_ENDPOINT,
+                ))
+            await db.close()
+
+        asyncio.run(_seed_new_member())
+
+        with TestClient(create_app(config)) as client:
+            msg = _system_message(
+                action="member_left",
+                target_agent_id=NEW_AGENT_ID,
+                sender_id=NEW_AGENT_ID,
+                sender_endpoint=NEW_AGENT_ENDPOINT,
+            )
+            response = client.post(
+                "/swarm/message", json=msg,
+                headers={
+                    "Content-Type": "application/json",
+                    "X-Agent-ID": NEW_AGENT_ID,
+                    "X-Swarm-Protocol": "0.1.0",
+                },
+            )
+            assert response.status_code == 200
+
+        members = _read_table(
+            db_path, "swarm_members",
+            where=f"agent_id = '{NEW_AGENT_ID}' AND swarm_id = '{SWARM_ID}'",
+        )
+        assert members == []
+
+        keys = _read_table(
+            db_path, "public_keys", where=f"agent_id = '{NEW_AGENT_ID}'",
+        )
+        assert len(keys) == 1
+        assert keys[0]["public_key"] == NEW_AGENT_PUBKEY
+
+    def test_member_kicked_deletes_swarm_members_keeps_public_keys(
+        self, tmp_path: Path,
+    ) -> None:
+        """member_kicked POST: swarm_members row removed, public_keys cache survives."""
+        db_path = tmp_path / "kicked.db"
+        _seed_swarm(db_path)
+        config = _make_config(db_path)
+
+        async def _seed_new_member() -> None:
+            db = DatabaseManager(db_path)
+            await db.initialize()
+            async with db.connection() as conn:
+                await conn.execute(
+                    "INSERT INTO swarm_members "
+                    "(agent_id, swarm_id, endpoint, public_key, joined_at) "
+                    "VALUES (?, ?, ?, ?, ?)",
+                    (
+                        NEW_AGENT_ID, SWARM_ID, NEW_AGENT_ENDPOINT,
+                        NEW_AGENT_PUBKEY, "2026-04-27T06:21:32.000Z",
+                    ),
+                )
+                await conn.commit()
+                await PublicKeyRepository(conn).store(PublicKeyEntry(
+                    agent_id=NEW_AGENT_ID,
+                    public_key=NEW_AGENT_PUBKEY,
+                    fetched_at=datetime.now(timezone.utc),
+                    endpoint=NEW_AGENT_ENDPOINT,
+                ))
+            await db.close()
+
+        asyncio.run(_seed_new_member())
+
+        with TestClient(create_app(config)) as client:
+            msg = _system_message(
+                action="member_kicked",
+                target_agent_id=NEW_AGENT_ID,
+                sender_id=MASTER_AGENT_ID,
+                sender_endpoint=MASTER_ENDPOINT,
+                extra_content={
+                    "initiated_by": MASTER_AGENT_ID,
+                    "reason": "Spamming",
+                },
+            )
+            response = client.post(
+                "/swarm/message", json=msg,
+                headers={
+                    "Content-Type": "application/json",
+                    "X-Agent-ID": MASTER_AGENT_ID,
+                    "X-Swarm-Protocol": "0.1.0",
+                },
+            )
+            assert response.status_code == 200
+
+        members = _read_table(
+            db_path, "swarm_members",
+            where=f"agent_id = '{NEW_AGENT_ID}' AND swarm_id = '{SWARM_ID}'",
+        )
+        assert members == []
+
+        keys = _read_table(
+            db_path, "public_keys", where=f"agent_id = '{NEW_AGENT_ID}'",
+        )
+        assert len(keys) == 1, "public_keys cache must survive membership churn"
+
+    def test_member_left_for_unknown_agent_is_noop(
+        self, tmp_path: Path,
+    ) -> None:
+        """member_left for an agent not in swarm_members is a clean no-op."""
+        db_path = tmp_path / "unknown_left.db"
+        _seed_swarm(db_path)
+        config = _make_config(db_path)
+
+        with TestClient(create_app(config)) as client:
+            msg = _system_message(
+                action="member_left",
+                target_agent_id="never-was-a-member",
+                sender_id="never-was-a-member",
+                sender_endpoint="https://noexist.example.com",
+            )
+            response = client.post(
+                "/swarm/message", json=msg,
+                headers={
+                    "Content-Type": "application/json",
+                    "X-Agent-ID": "never-was-a-member",
+                    "X-Swarm-Protocol": "0.1.0",
+                },
+            )
+            assert response.status_code == 200
+
+        # No effect on the seeded master + local rows
+        members = _read_table(db_path, "swarm_members")
+        agent_ids = {m["agent_id"] for m in members}
+        assert agent_ids == {MASTER_AGENT_ID, LOCAL_AGENT_ID}


### PR DESCRIPTION
## Summary

Receiver-side dispatch for `member_joined`, `member_left`, and `member_kicked` system messages, so the local `swarm_members` table updates when broadcasts arrive. Without this, members can only reach a newly-joined agent via broadcast — direct A2A from existing members to a new agent fails silently on the sender side until manual intervention.

Path 1b from the issue thread: lazy-fetch `/info` for the new member's `public_key`, pull `swarm_id` from the message envelope, write all 5 NOT NULL columns. No wire-format change.

## Behaviors

- `member_joined`: `INSERT OR IGNORE INTO swarm_members` (5 cols) + `INSERT OR REPLACE INTO public_keys` (4 cols). Idempotent on duplicate broadcasts.
- `member_left` / `member_kicked`: `DELETE FROM swarm_members` only. `public_keys` cache survives churn — in-flight signatures still verify, and a re-join does not require a re-fetch.
- `/info` unreachable / non-200 / missing field / agent_id mismatch: log a warning, swallow, do not insert. Message still accepted (200 queued). Lazy-fetch in the signature verifier populates `public_keys` on first inbound verify as a fallback.
- Last-resort guard wrapping the dispatcher: any unexpected exception logs but does not block message acceptance.

## URL convention

`/info` URL is `{endpoint.rstrip('/')}/info` — endpoint already includes `/swarm`, route appended bare. Mirrors the join URL pattern in `src/client/operations.py` (`{endpoint.rstrip('/')}/join`).

## Files

- `src/server/system_dispatch.py` (new) — receiver-side dispatcher
- `src/server/routes/message.py` — wired in after inbox persistence, accepts `local_agent_id` for the `/info` X-Agent-ID header
- `src/server/app.py` — passes `config.agent.agent_id` to the message router
- `tests/test_receiver_member_sync.py` (new) — 6 test cases

## Test plan

```
tests/test_receiver_member_sync.py::TestMemberJoinedReceiverDispatch::test_happy_path_writes_swarm_members_and_public_keys PASSED
tests/test_receiver_member_sync.py::TestMemberJoinedReceiverDispatch::test_swarm_info_unreachable_does_not_crash PASSED
tests/test_receiver_member_sync.py::TestMemberJoinedReceiverDispatch::test_idempotent_re_receipt_does_not_duplicate PASSED
tests/test_receiver_member_sync.py::TestMemberRemovedReceiverDispatch::test_member_left_deletes_swarm_members_keeps_public_keys PASSED
tests/test_receiver_member_sync.py::TestMemberRemovedReceiverDispatch::test_member_kicked_deletes_swarm_members_keeps_public_keys PASSED
tests/test_receiver_member_sync.py::TestMemberRemovedReceiverDispatch::test_member_left_for_unknown_agent_is_noop PASSED
```

Full suite: 507 passed (501 baseline + 6 new). No regressions.

- [x] Happy path (`/info` mock returns 200) → 5+4 cols populated, `/info` URL asserted
- [x] `/info` unreachable (httpx.ConnectError raised) → message queued, tables unchanged, inbox row exists
- [x] Idempotent re-receipt (same payload, different message_id) → exactly one `swarm_members` row
- [x] `member_left` → `swarm_members` row removed, `public_keys` cache survives
- [x] `member_kicked` → `swarm_members` row removed, `public_keys` cache survives
- [x] `member_left` for unknown agent → clean no-op, no exception

### Operator-shape smoke

End-to-end via `client.post('/swarm/message', json=msg)` against a real `create_app(config)` + real `DatabaseManager`, then `sqlite3` read-back:

```
=== BEFORE OPERATOR POST ===
swarm_members count: 2
public_keys count:  0
=== POST /swarm/message member_joined for axis ===
HTTP status: 200
HTTP body:   {'status': 'queued', 'message_id': 'aaaaaaaa-...'}
=== AFTER OPERATOR POST ===
swarm_members count: 3 (expect 3 — incremented from 2)
public_keys count:  1 (expect 1 — pre-warmed)
--- /info call URL ---
  https://axis.marbell.com/swarm/info
```

## Anti-patterns avoided

- No wire-format change (path 1a rejected at brief)
- No `INSERT OR REPLACE` on `swarm_members` — duplicate broadcasts must not clobber state
- No `DELETE` from `public_keys` on leave/kick — cache survives churn
- No crash on `/info` unreachable — log + continue
- No SKILL changes (#196 just merged, out of scope)

## Refs

- Refs #197 — leaving close to maintainer review (Nexus authored the issue with the empirical evidence)

Refs #197

🤖 Generated with [Claude Code](https://claude.com/claude-code)