### PR TITLE
feat(cli): swarm members — list swarm members and endpoints

### DIFF
--- a/src/cli/commands/members.py
+++ b/src/cli/commands/members.py
@@ -24,7 +24,7 @@ _HEALTH_TIMEOUT = 5.0
 _PUBKEY_TRUNC_CHARS = 8
 
 
-async def _load_members(swarm_id: UUID) -> list[SwarmMember]:
+async def _load_members(swarm_id: UUID) -> list[SwarmMember] | None:
     """Load members for ``swarm_id`` via the membership repository.
 
     Returns an empty list when the agent is a member of the swarm but the

--- a/src/cli/commands/members.py
+++ b/src/cli/commands/members.py
@@ -1,0 +1,167 @@
+"""List members of a swarm and their endpoints.
+
+Reads ``swarm_members`` via the state-layer ``MembershipRepository`` (no raw
+SQL in the CLI).  Optionally probes each member's ``/health`` endpoint in
+parallel and reports per-member status.
+"""
+
+import asyncio
+from uuid import UUID
+
+import httpx
+import typer
+from rich.console import Console
+
+from src.cli.output import format_error, format_table, json_output
+from src.cli.utils import ConfigManager, resolve_swarm_id, SwarmIdError
+from src.cli.utils.config import ConfigError
+from src.state import DatabaseManager, MembershipRepository
+from src.state.models import SwarmMember
+
+console = Console()
+
+_HEALTH_TIMEOUT = 5.0
+_PUBKEY_TRUNC_CHARS = 8
+
+
+async def _load_members(swarm_id: UUID) -> list[SwarmMember]:
+    """Load members for ``swarm_id`` via the membership repository.
+
+    Returns an empty list when the agent is a member of the swarm but the
+    swarm has no other members; returns ``None`` when the agent is not a
+    member of the requested swarm at all (used by the caller to distinguish
+    "empty swarm" from "not a member").
+    """
+    config = ConfigManager()
+    agent_config = config.load()
+
+    db = DatabaseManager(agent_config.db_path)
+    await db.initialize()
+
+    async with db.connection() as conn:
+        repo = MembershipRepository(conn)
+        membership = await repo.get_swarm(str(swarm_id))
+
+    if membership is None:
+        return None
+    return list(membership.members)
+
+
+async def _probe_member(member: SwarmMember) -> str:
+    """TLS handshake + GET ``<endpoint>/health``; return short status string.
+
+    Uses the agent's configured ``endpoint`` directly (it already includes
+    the path component, e.g. ``https://host/swarm``); the health probe hits
+    ``<endpoint>/health`` regardless of the path's exact shape, matching the
+    contract documented in the originating issue.
+    """
+    url = member.endpoint.rstrip("/") + "/health"
+    try:
+        async with httpx.AsyncClient(timeout=_HEALTH_TIMEOUT) as client:
+            resp = await client.get(url)
+        if resp.status_code == 200:
+            return "OK"
+        return f"HTTP {resp.status_code}"
+    except httpx.TimeoutException:
+        return "timeout"
+    except (
+        httpx.ConnectError,
+        httpx.RemoteProtocolError,
+        httpx.ReadError,
+    ) as e:
+        # SSL/TLS errors are wrapped under ConnectError on httpx; surface
+        # the underlying class name where it helps disambiguate.
+        cause = e.__cause__
+        if cause is not None and "SSL" in type(cause).__name__.upper():
+            return "TLS error"
+        if "SSL" in str(e).upper() or "CERTIFICATE" in str(e).upper():
+            return "TLS error"
+        return f"connect error: {type(e).__name__}"
+    except Exception as e:  # pragma: no cover - defensive
+        return f"error: {type(e).__name__}"
+
+
+async def _probe_all(members: list[SwarmMember]) -> list[str]:
+    """Probe every member in parallel; preserve input order."""
+    return await asyncio.gather(*(_probe_member(m) for m in members))
+
+
+def _truncate_pubkey(pk: str, n: int = _PUBKEY_TRUNC_CHARS) -> str:
+    """Return ``pk`` truncated to ``n`` chars + ellipsis when longer."""
+    if len(pk) <= n:
+        return pk
+    return f"{pk[:n]}…"
+
+
+def members_command(
+    swarm_id: str | None,
+    health: bool,
+    json_flag: bool,
+) -> None:
+    """List members of a swarm and their endpoints."""
+    try:
+        swarm_uuid = resolve_swarm_id(swarm_id)
+    except SwarmIdError as e:
+        format_error(console, str(e))
+        raise typer.Exit(code=2)
+    except ValueError as e:
+        format_error(console, str(e))
+        raise typer.Exit(code=2)
+
+    try:
+        members = asyncio.run(_load_members(swarm_uuid))
+    except ConfigError as e:
+        format_error(console, str(e), hint="Run 'swarm init' to configure your agent")
+        raise typer.Exit(code=1)
+    except Exception as e:
+        format_error(console, f"Failed to load members: {e}")
+        raise typer.Exit(code=1)
+
+    if members is None:
+        format_error(
+            console,
+            f"Not a member of swarm {swarm_uuid}",
+            hint="Use 'swarm list' to see swarms this agent belongs to",
+        )
+        raise typer.Exit(code=5)
+
+    statuses: list[str] = []
+    if health and members:
+        try:
+            statuses = asyncio.run(_probe_all(members))
+        except Exception as e:
+            format_error(console, f"Health probe failed: {e}")
+            raise typer.Exit(code=1)
+
+    if json_flag:
+        data = {
+            "swarm_id": str(swarm_uuid),
+            "member_count": len(members),
+            "members": [
+                {
+                    "agent_id": m.agent_id,
+                    "endpoint": m.endpoint,
+                    "public_key": m.public_key,
+                    "joined_at": m.joined_at.isoformat(),
+                    **({"health": statuses[i]} if health else {}),
+                }
+                for i, m in enumerate(members)
+            ],
+        }
+        json_output(console, data)
+        return
+
+    if not members:
+        console.print(f"[dim]No members in swarm {swarm_uuid}.[/dim]")
+        return
+
+    columns = ["AGENT_ID", "ENDPOINT", "PUBLIC_KEY"]
+    if health:
+        columns.append("HEALTH")
+    rows: list[list[str]] = []
+    for i, m in enumerate(members):
+        row = [m.agent_id, m.endpoint, _truncate_pubkey(m.public_key)]
+        if health:
+            row.append(statuses[i])
+        rows.append(row)
+    format_table(console, f"Members of swarm {swarm_uuid}", columns, rows)

--- a/src/cli/commands/members.py
+++ b/src/cli/commands/members.py
@@ -13,7 +13,7 @@ import typer
 from rich.console import Console
 
 from src.cli.output import format_error, format_table, json_output
-from src.cli.utils import ConfigManager, resolve_swarm_id, SwarmIdError
+from src.cli.utils import ConfigManager, SwarmIdError, resolve_swarm_id
 from src.cli.utils.config import ConfigError
 from src.state import DatabaseManager, MembershipRepository
 from src.state.models import SwarmMember

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -111,7 +111,9 @@ def members(
         None, "-s", "--swarm", "--swarm-id", help="Swarm ID (UUID)"
     ),
     health: bool = typer.Option(
-        False, "--health", help="TLS+/health probe each member endpoint in parallel",
+        False,
+        "--health",
+        help="TLS+/health probe each member endpoint in parallel",
     ),
     json_flag: bool = typer.Option(False, "--json", help="Output as JSON"),
 ) -> None:
@@ -121,27 +123,41 @@ def members(
 
 @app.command("purge")
 def purge(
-    messages: bool = typer.Option(False, "--messages", help="Purge deleted inbox messages"),
+    messages: bool = typer.Option(
+        False, "--messages", help="Purge deleted inbox messages"
+    ),
     sessions: bool = typer.Option(False, "--sessions", help="Purge expired sessions"),
     include_archived: bool = typer.Option(
-        False, "--include-archived", help="Also purge archived messages",
+        False,
+        "--include-archived",
+        help="Also purge archived messages",
     ),
     timeout_minutes: int = typer.Option(
         60, "--timeout-minutes", help="Session timeout (minutes)"
     ),
     retention_hours: int = typer.Option(
-        24, "--retention-hours", help="Only purge messages deleted more than N hours ago",
+        24,
+        "--retention-hours",
+        help="Only purge messages deleted more than N hours ago",
     ),
     force: bool = typer.Option(
-        False, "--force", help="Bypass retention window and purge all deleted messages",
+        False,
+        "--force",
+        help="Bypass retention window and purge all deleted messages",
     ),
     yes: bool = typer.Option(False, "-y", "--yes", help="Skip confirmation"),
     json_flag: bool = typer.Option(False, "--json", help="Output as JSON"),
 ) -> None:
     """Purge soft-deleted inbox messages and expired sessions."""
     purge_command(
-        messages, sessions, include_archived, timeout_minutes,
-        retention_hours, force, yes, json_flag,
+        messages,
+        sessions,
+        include_archived,
+        timeout_minutes,
+        retention_hours,
+        force,
+        yes,
+        json_flag,
     )
 
 
@@ -149,7 +165,11 @@ def purge(
 def send(
     swarm_id: str = typer.Option(None, "-s", "--swarm", help="Swarm ID"),
     message: str = typer.Option(
-        None, "-m", "--message", "--body", help="Content (or pipe via stdin)",
+        None,
+        "-m",
+        "--message",
+        "--body",
+        help="Content (or pipe via stdin)",
     ),
     to: str = typer.Option(None, "-t", "--to", help="Recipient (default: all)"),
     json_flag: bool = typer.Option(False, "--json"),
@@ -174,23 +194,36 @@ def messages(
     swarm_id: str = typer.Option(None, "-s", "--swarm", help="Swarm ID"),
     limit: int = typer.Option(10, "-l", "--limit", help="Max messages to show"),
     status_filter: str = typer.Option(
-        "unread", "--status", help="Filter: unread|read|archived|all",
+        "unread",
+        "--status",
+        help="Filter: unread|read|archived|all",
     ),
     archive: str = typer.Option(None, "--archive", help="Archive a message by ID"),
     delete: str = typer.Option(None, "--delete", help="Soft-delete a message by ID"),
     no_mark_read: bool = typer.Option(
-        False, "--no-mark-read", help="Don't auto-mark unread messages as read",
+        False,
+        "--no-mark-read",
+        help="Don't auto-mark unread messages as read",
     ),
     count: bool = typer.Option(False, "--count", help="Show inbox counts only"),
     archive_all: bool = typer.Option(
-        False, "--archive-all", help="Archive all read messages in swarm",
+        False,
+        "--archive-all",
+        help="Archive all read messages in swarm",
     ),
     json_flag: bool = typer.Option(False, "--json", help="Output as JSON"),
 ) -> None:
     """List and manage received messages."""
     messages_command(
-        swarm_id, limit, status_filter, archive, delete,
-        no_mark_read, count, json_flag, archive_all,
+        swarm_id,
+        limit,
+        status_filter,
+        archive,
+        delete,
+        no_mark_read,
+        count,
+        json_flag,
+        archive_all,
     )
 
 

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -13,6 +13,7 @@ from src.cli.commands.join import join_command
 from src.cli.commands.kick import kick_command
 from src.cli.commands.leave import leave_command
 from src.cli.commands.list_swarms import list_command
+from src.cli.commands.members import members_command
 from src.cli.commands.messages import messages_command
 from src.cli.commands.mute import mute_command
 from src.cli.commands.purge import purge_command
@@ -102,6 +103,20 @@ def list_swarms(
 ) -> None:
     """List swarms this agent belongs to."""
     list_command(swarm_id, members, json_flag)
+
+
+@app.command("members")
+def members(
+    swarm_id: str = typer.Option(
+        None, "-s", "--swarm", "--swarm-id", help="Swarm ID (UUID)"
+    ),
+    health: bool = typer.Option(
+        False, "--health", help="TLS+/health probe each member endpoint in parallel",
+    ),
+    json_flag: bool = typer.Option(False, "--json", help="Output as JSON"),
+) -> None:
+    """List members of a swarm and their endpoints."""
+    members_command(swarm_id, health, json_flag)
 
 
 @app.command("purge")

--- a/tests/cli/test_members.py
+++ b/tests/cli/test_members.py
@@ -1,0 +1,296 @@
+"""Tests for ``swarm members`` command."""
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+import yaml
+from typer.testing import CliRunner
+
+from src.cli.main import app
+from src.cli.utils.config import ConfigManager
+from src.state.models import SwarmMember
+
+runner = CliRunner()
+
+SWARM_UUID = "716a4150-ab9d-4b54-a2a8-f2b7c607c21e"
+UNKNOWN_SWARM_UUID = "00000000-0000-0000-0000-000000000000"
+
+
+def _make_member(
+    agent_id: str = "alice",
+    endpoint: str = "https://alice.example.com/swarm",
+    public_key: str = "abcdefgh-very-long-public-key-string",
+) -> SwarmMember:
+    return SwarmMember(
+        agent_id=agent_id,
+        endpoint=endpoint,
+        public_key=public_key,
+        joined_at=datetime(2026, 5, 8, 12, 0, 0, tzinfo=timezone.utc),
+    )
+
+
+def _setup_config(tmpdir: str, monkeypatch) -> Path:
+    """Create a config dir with default_swarm pointing at SWARM_UUID."""
+    config_dir = Path(tmpdir) / "swarm"
+    config_dir.mkdir()
+    (config_dir / "config.yaml").write_text(
+        yaml.dump(
+            {
+                "agent_id": "test-agent",
+                "endpoint": "https://test.example.com/swarm",
+                "default_swarm": SWARM_UUID,
+            }
+        )
+    )
+    (config_dir / "agent.key").write_text("dummy-key")
+    monkeypatch.setattr(ConfigManager, "DEFAULT_DIR", config_dir)
+    return config_dir
+
+
+class TestMembersListing:
+    """Default tabular listing case."""
+
+    def test_basic_listing(self, monkeypatch):
+        with TemporaryDirectory() as tmpdir:
+            _setup_config(tmpdir, monkeypatch)
+
+            members = [
+                _make_member("alice", "https://alice.example.com/swarm", "AAAAbbbbCCCCddddEEEE"),
+                _make_member("bob", "https://bob.example.com/swarm", "FFFFggggHHHHiiiiJJJJ"),
+            ]
+            with patch(
+                "src.cli.commands.members._load_members",
+                new=AsyncMock(return_value=members),
+            ):
+                result = runner.invoke(app, ["members"])
+
+            assert result.exit_code == 0
+            assert "AGENT_ID" in result.stdout
+            assert "ENDPOINT" in result.stdout
+            assert "PUBLIC_KEY" in result.stdout
+            assert "alice" in result.stdout
+            assert "bob" in result.stdout
+            assert "https://alice.example.com/swarm" in result.stdout
+            # Public key truncated to 8 chars + ellipsis -- full key absent.
+            assert "AAAAbbbb" in result.stdout
+            assert "AAAAbbbbCCCCddddEEEE" not in result.stdout
+
+
+class TestMembersJsonOutput:
+    """``--json`` returns full data with full public keys."""
+
+    def test_json_output(self, monkeypatch):
+        with TemporaryDirectory() as tmpdir:
+            _setup_config(tmpdir, monkeypatch)
+
+            full_pk = "AAAAbbbbCCCCddddEEEEffffGGGGhhhh"
+            members = [_make_member("alice", "https://alice.example.com/swarm", full_pk)]
+            with patch(
+                "src.cli.commands.members._load_members",
+                new=AsyncMock(return_value=members),
+            ):
+                result = runner.invoke(app, ["members", "--json"])
+
+            assert result.exit_code == 0
+            data = json.loads(result.stdout)
+            assert data["swarm_id"] == SWARM_UUID
+            assert data["member_count"] == 1
+            assert len(data["members"]) == 1
+            entry = data["members"][0]
+            assert entry["agent_id"] == "alice"
+            assert entry["endpoint"] == "https://alice.example.com/swarm"
+            # JSON path returns the FULL public key, not truncated.
+            assert entry["public_key"] == full_pk
+            assert "joined_at" in entry
+            # No --health, so no health field.
+            assert "health" not in entry
+
+
+class TestMembersEmptySwarm:
+    """The swarm exists but has zero members."""
+
+    def test_empty_swarm_table(self, monkeypatch):
+        with TemporaryDirectory() as tmpdir:
+            _setup_config(tmpdir, monkeypatch)
+
+            with patch(
+                "src.cli.commands.members._load_members",
+                new=AsyncMock(return_value=[]),
+            ):
+                result = runner.invoke(app, ["members"])
+
+            assert result.exit_code == 0
+            assert "No members" in result.stdout
+
+    def test_empty_swarm_json(self, monkeypatch):
+        with TemporaryDirectory() as tmpdir:
+            _setup_config(tmpdir, monkeypatch)
+
+            with patch(
+                "src.cli.commands.members._load_members",
+                new=AsyncMock(return_value=[]),
+            ):
+                result = runner.invoke(app, ["members", "--json"])
+
+            assert result.exit_code == 0
+            data = json.loads(result.stdout)
+            assert data["swarm_id"] == SWARM_UUID
+            assert data["member_count"] == 0
+            assert data["members"] == []
+
+
+class TestMembersUnknownSwarmId:
+    """``--swarm-id <uuid>`` for a swarm the agent is not a member of."""
+
+    def test_unknown_swarm_exits_nonzero(self, monkeypatch):
+        with TemporaryDirectory() as tmpdir:
+            _setup_config(tmpdir, monkeypatch)
+
+            # Repository returns None when the agent isn't a member.
+            with patch(
+                "src.cli.commands.members._load_members",
+                new=AsyncMock(return_value=None),
+            ):
+                result = runner.invoke(
+                    app, ["members", "--swarm-id", UNKNOWN_SWARM_UUID]
+                )
+
+            assert result.exit_code == 5
+            assert "Not a member" in result.stdout
+            assert UNKNOWN_SWARM_UUID in result.stdout
+
+    def test_invalid_uuid_exits_with_validation_code(self, monkeypatch):
+        with TemporaryDirectory() as tmpdir:
+            _setup_config(tmpdir, monkeypatch)
+
+            result = runner.invoke(app, ["members", "--swarm-id", "not-a-uuid"])
+
+            assert result.exit_code == 2
+
+
+class TestMembersHealthFlag:
+    """``--health`` probes endpoints in parallel; uses mocked HTTP client."""
+
+    def test_health_ok(self, monkeypatch):
+        with TemporaryDirectory() as tmpdir:
+            _setup_config(tmpdir, monkeypatch)
+
+            members = [
+                _make_member("alice", "https://alice.example.com/swarm"),
+                _make_member("bob", "https://bob.example.com/swarm"),
+            ]
+
+            class _MockResponse:
+                def __init__(self, status: int) -> None:
+                    self.status_code = status
+
+            class _MockClient:
+                def __init__(self, *args, **kwargs) -> None:
+                    pass
+
+                async def __aenter__(self) -> "_MockClient":
+                    return self
+
+                async def __aexit__(self, *args) -> None:
+                    return None
+
+                async def get(self, url: str) -> _MockResponse:
+                    assert url.endswith("/health")
+                    return _MockResponse(200)
+
+            with patch(
+                "src.cli.commands.members._load_members",
+                new=AsyncMock(return_value=members),
+            ), patch("src.cli.commands.members.httpx.AsyncClient", _MockClient):
+                result = runner.invoke(app, ["members", "--health", "--json"])
+
+            assert result.exit_code == 0
+            data = json.loads(result.stdout)
+            assert all(m["health"] == "OK" for m in data["members"])
+
+    def test_health_mixed_statuses(self, monkeypatch):
+        with TemporaryDirectory() as tmpdir:
+            _setup_config(tmpdir, monkeypatch)
+
+            members = [
+                _make_member("alice", "https://alice.example.com/swarm"),
+                _make_member("bob", "https://bob.example.com/swarm"),
+                _make_member("carol", "https://carol.example.com/swarm"),
+                _make_member("dave", "https://dave.example.com/swarm"),
+            ]
+
+            class _Resp:
+                def __init__(self, status: int) -> None:
+                    self.status_code = status
+
+            class _MockClient:
+                def __init__(self, *args, **kwargs) -> None:
+                    pass
+
+                async def __aenter__(self) -> "_MockClient":
+                    return self
+
+                async def __aexit__(self, *args) -> None:
+                    return None
+
+                async def get(self, url: str) -> _Resp:
+                    if "alice" in url:
+                        return _Resp(200)
+                    if "bob" in url:
+                        return _Resp(503)
+                    if "carol" in url:
+                        raise httpx.TimeoutException("timed out")
+                    if "dave" in url:
+                        raise httpx.ConnectError("SSL: CERTIFICATE_VERIFY_FAILED")
+                    raise AssertionError(f"Unexpected url {url}")
+
+            with patch(
+                "src.cli.commands.members._load_members",
+                new=AsyncMock(return_value=members),
+            ), patch("src.cli.commands.members.httpx.AsyncClient", _MockClient):
+                result = runner.invoke(app, ["members", "--health", "--json"])
+
+            assert result.exit_code == 0
+            data = json.loads(result.stdout)
+            health = {m["agent_id"]: m["health"] for m in data["members"]}
+            assert health["alice"] == "OK"
+            assert health["bob"] == "HTTP 503"
+            assert health["carol"] == "timeout"
+            assert health["dave"] == "TLS error"
+
+    def test_health_table_includes_health_column(self, monkeypatch):
+        with TemporaryDirectory() as tmpdir:
+            _setup_config(tmpdir, monkeypatch)
+
+            members = [_make_member("alice", "https://alice.example.com/swarm")]
+
+            class _Resp:
+                status_code = 200
+
+            class _MockClient:
+                def __init__(self, *args, **kwargs) -> None:
+                    pass
+
+                async def __aenter__(self) -> "_MockClient":
+                    return self
+
+                async def __aexit__(self, *args) -> None:
+                    return None
+
+                async def get(self, url: str) -> _Resp:
+                    return _Resp()
+
+            with patch(
+                "src.cli.commands.members._load_members",
+                new=AsyncMock(return_value=members),
+            ), patch("src.cli.commands.members.httpx.AsyncClient", _MockClient):
+                result = runner.invoke(app, ["members", "--health"])
+
+            assert result.exit_code == 0
+            assert "HEALTH" in result.stdout
+            assert "OK" in result.stdout

--- a/tests/cli/test_members.py
+++ b/tests/cli/test_members.py
@@ -7,7 +7,6 @@ from tempfile import TemporaryDirectory
 from unittest.mock import AsyncMock, patch
 
 import httpx
-import pytest
 import yaml
 from typer.testing import CliRunner
 

--- a/tests/cli/test_members.py
+++ b/tests/cli/test_members.py
@@ -59,8 +59,12 @@ class TestMembersListing:
             _setup_config(tmpdir, monkeypatch)
 
             members = [
-                _make_member("alice", "https://alice.example.com/swarm", "AAAAbbbbCCCCddddEEEE"),
-                _make_member("bob", "https://bob.example.com/swarm", "FFFFggggHHHHiiiiJJJJ"),
+                _make_member(
+                    "alice", "https://alice.example.com/swarm", "AAAAbbbbCCCCddddEEEE"
+                ),
+                _make_member(
+                    "bob", "https://bob.example.com/swarm", "FFFFggggHHHHiiiiJJJJ"
+                ),
             ]
             with patch(
                 "src.cli.commands.members._load_members",
@@ -88,7 +92,9 @@ class TestMembersJsonOutput:
             _setup_config(tmpdir, monkeypatch)
 
             full_pk = "AAAAbbbbCCCCddddEEEEffffGGGGhhhh"
-            members = [_make_member("alice", "https://alice.example.com/swarm", full_pk)]
+            members = [
+                _make_member("alice", "https://alice.example.com/swarm", full_pk)
+            ]
             with patch(
                 "src.cli.commands.members._load_members",
                 new=AsyncMock(return_value=members),
@@ -202,10 +208,13 @@ class TestMembersHealthFlag:
                     assert url.endswith("/health")
                     return _MockResponse(200)
 
-            with patch(
-                "src.cli.commands.members._load_members",
-                new=AsyncMock(return_value=members),
-            ), patch("src.cli.commands.members.httpx.AsyncClient", _MockClient):
+            with (
+                patch(
+                    "src.cli.commands.members._load_members",
+                    new=AsyncMock(return_value=members),
+                ),
+                patch("src.cli.commands.members.httpx.AsyncClient", _MockClient),
+            ):
                 result = runner.invoke(app, ["members", "--health", "--json"])
 
             assert result.exit_code == 0
@@ -248,10 +257,13 @@ class TestMembersHealthFlag:
                         raise httpx.ConnectError("SSL: CERTIFICATE_VERIFY_FAILED")
                     raise AssertionError(f"Unexpected url {url}")
 
-            with patch(
-                "src.cli.commands.members._load_members",
-                new=AsyncMock(return_value=members),
-            ), patch("src.cli.commands.members.httpx.AsyncClient", _MockClient):
+            with (
+                patch(
+                    "src.cli.commands.members._load_members",
+                    new=AsyncMock(return_value=members),
+                ),
+                patch("src.cli.commands.members.httpx.AsyncClient", _MockClient),
+            ):
                 result = runner.invoke(app, ["members", "--health", "--json"])
 
             assert result.exit_code == 0
@@ -284,10 +296,13 @@ class TestMembersHealthFlag:
                 async def get(self, url: str) -> _Resp:
                     return _Resp()
 
-            with patch(
-                "src.cli.commands.members._load_members",
-                new=AsyncMock(return_value=members),
-            ), patch("src.cli.commands.members.httpx.AsyncClient", _MockClient):
+            with (
+                patch(
+                    "src.cli.commands.members._load_members",
+                    new=AsyncMock(return_value=members),
+                ),
+                patch("src.cli.commands.members.httpx.AsyncClient", _MockClient),
+            ):
                 result = runner.invoke(app, ["members", "--health"])
 
             assert result.exit_code == 0


### PR DESCRIPTION
## Summary

Adds `swarm members` command. Enumerates the members of a swarm and their endpoints + public keys via the existing `MembershipRepository.get_swarm()` (no raw SQL in the CLI). Closes the visibility gap surfaced by Sage's 2026-05-08 axis-naming-mismatch incident: previously the only way to learn the actual `agent_id` of a registered member was to query `swarm.db` directly.

Closes #203.

## Implementation

- New file: `src/cli/commands/members.py` (~170 lines, single responsibility)
- Wired into `src/cli/main.py` as `@app.command("members")`
- Tests: `tests/cli/test_members.py` (9 tests, all passing; full `tests/cli/` suite at 158 passing)

The command uses `MembershipRepository.get_swarm(swarm_id)` from the state layer. No new state-layer methods needed — `get_swarm()` already returns a `SwarmMembership` whose `.members` tuple has the agent_id / endpoint / public_key / joined_at fields the issue calls for. Returns `None` when the agent is not a member of the requested swarm; the CLI surfaces that as exit code 5 (consistent with `kick.py`'s "not found" semantics).

`--health` uses `asyncio.gather` over per-member `httpx.AsyncClient` GETs to `<endpoint>/health` with a 5s timeout each. Reports status as `OK / HTTP <code> / timeout / TLS error / connect error: <type>`. SSL errors are detected by inspecting the underlying cause's class name (httpx wraps `ssl.SSLError` under `ConnectError`).

The flag spelling: existing CLI commands use `-s/--swarm`. The issue text uses `--swarm-id`. I added `--swarm-id` as a third alias on the same Typer Option so both spellings work and the existing convention is preserved.

## Acceptance criteria

- [x] `swarm members` returns a tabular list of registered members for the resolved swarm (agent_id, endpoint, truncated public key 8 chars + ellipsis)
- [x] `--json` returns the full list as JSON with full untruncated public keys, no decoration
- [x] `--swarm-id <UUID>` (alias of `-s/--swarm`) filters to that swarm; exits non-zero (code 5) when the agent is not a member
- [x] `--health` performs TLS+GET to `<endpoint>/health` per member, 5s timeout, in parallel via `asyncio.gather`. Reports OK / HTTP <code> / timeout / TLS error
- [x] Implementation uses `MembershipRepository.get_swarm()` (state-layer repository) — NO raw SQL in the CLI
- [x] Unit tests: basic listing + `--json` + empty swarm + unknown `--swarm-id` error + `--health` covered with mocked HTTP client (OK, HTTP 503, timeout, TLS error paths)
- [x] CLI help text follows the Typer `@app.command` docstring convention
- [x] No new dependencies (httpx already in tree)

## Test plan

- [x] `venv/bin/python -m pytest tests/cli/test_members.py -v` — 9 passed
- [x] `venv/bin/python -m pytest tests/cli/ -q` — 158 passed (no regressions)
- [x] `swarm members` against live local DB — returns the expected 4-member listing (nexus-marbell, axis, kelvin, finml-sage)
- [x] `swarm members --json` — full 44-char public keys present in JSON output
- [x] `swarm members --swarm-id <unknown-uuid>` — exits 5 with "Not a member of swarm <id>" error
- [x] `swarm members --help` — docstring renders as help text per existing-command convention

## Out of scope

Per the issue: no inviting/kicking, no protocol schema changes, no cross-swarm listing, no server-side endpoint changes. This command reads only what's already in the local DB.