### PR TITLE
feat(wake): zellij as peer invoker to tmux (default-off)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -89,10 +89,17 @@ WAKE_TIMEOUT=5.0
 # [optional] Enable/disable the /api/wake endpoint (default: true)
 WAKE_EP_ENABLED=true
 
-# [optional] Invocation method: 'tmux' or 'noop' (default: noop)
-# - tmux: sends a notification into a running tmux session via send-keys
-#          (set WAKE_EP_TMUX_TARGET). No SDK required.
-# - noop: does nothing (safe default)
+# [optional] Invocation method: 'tmux', 'zellij', or 'noop' (default: noop)
+# - tmux:   sends a notification into a running tmux session via send-keys
+#           (set WAKE_EP_TMUX_TARGET). No SDK required.
+# - zellij: sends a notification into a running zellij session via
+#           'zellij --session ... action write-chars/send-keys' (set
+#           WAKE_EP_ZELLIJ_SESSION). No SDK required. Empirical TUI-layer
+#           verification under Codex CLI is pending Phase 0.C of the
+#           web-codex-user-ideoon project; verified at the zellij CLI
+#           layer (zellij 0.45.0 cli.rs) against the same PTY code path
+#           as real keyboard input.
+# - noop:   does nothing (safe default)
 WAKE_EP_INVOKE_METHOD=noop
 
 # [optional] Shared secret for X-Wake-Secret header authentication.
@@ -116,3 +123,16 @@ WAKE_EP_SESSION_TIMEOUT=30
 # No AI relay -- just a tmux send-keys call.
 # Examples: 'main:0', 'orchestrator', 'nexus:0.0'
 #WAKE_EP_TMUX_TARGET=main:0
+
+# ---------------------------------------------------------------------------
+# Wake endpoint: Zellij options (used when WAKE_EP_INVOKE_METHOD=zellij)
+# ---------------------------------------------------------------------------
+
+# [required when method is zellij] Zellij session name.
+# Notification is delivered to the focused pane of that session via
+# 'zellij --session <name> action write-chars <text>' followed by
+# 'zellij --session <name> action send-keys "Enter"'. Per-pane
+# targeting via --pane-id is intentionally not exposed; the focused
+# pane is the recipient.
+# Examples: 'codex', 'orchestrator', 'main'
+#WAKE_EP_ZELLIJ_SESSION=codex

--- a/src/server/app.py
+++ b/src/server/app.py
@@ -19,6 +19,7 @@ from fastapi.responses import JSONResponse
 from pydantic import ValidationError
 from src.server.config import ServerConfig, load_config_from_env
 from src.server.invoke_tmux import TmuxInvokeConfig
+from src.server.invoke_zellij import ZellijInvokeConfig
 from src.server.invoker import AgentInvoker
 from src.server.middleware.rate_limit import RateLimitMiddleware
 from src.server.middleware.logging import RequestLoggingMiddleware
@@ -57,11 +58,15 @@ def _build_invoker(config: ServerConfig) -> AgentInvoker:
     """Build an AgentInvoker from the wake endpoint configuration."""
     wep = config.wake_endpoint
     tmux_config = None
+    zellij_config = None
     if wep.invoke_method == "tmux":
         tmux_config = TmuxInvokeConfig(tmux_target=wep.tmux_target)
+    elif wep.invoke_method == "zellij":
+        zellij_config = ZellijInvokeConfig(zellij_session=wep.zellij_session)
     return AgentInvoker(
         method=wep.invoke_method,
         tmux_config=tmux_config,
+        zellij_config=zellij_config,
     )
 
 

--- a/src/server/config.py
+++ b/src/server/config.py
@@ -53,11 +53,14 @@ class WakeEndpointConfig:
 
     Enabled by default.  Set ``WAKE_EP_ENABLED=false`` to disable.
 
-    ``invoke_method``: how to start the agent -- 'tmux' or 'noop'.
+    ``invoke_method``: how to start the agent -- 'tmux', 'zellij', or 'noop'.
     ``secret``: shared secret for X-Wake-Secret header auth. Empty disables auth.
     ``session_file``: path to session state file for duplicate-invocation guard.
     ``session_timeout_minutes``: how long before an active session is considered expired.
     ``tmux_target``: tmux session/window/pane target for the tmux relay method.
+    ``zellij_session``: zellij session name for the zellij relay method
+        (passed via ``zellij --session``; the focused pane of that
+        session receives the notification).
     """
 
     enabled: bool = True
@@ -66,6 +69,7 @@ class WakeEndpointConfig:
     session_file: str = "/root/.swarm/session.json"
     session_timeout_minutes: int = 30
     tmux_target: str = ""
+    zellij_session: str = ""
 
 
 @dataclass(frozen=True)
@@ -140,6 +144,13 @@ def load_config_from_env() -> ServerConfig:
             "Set it to a tmux session target (e.g. 'main:0')."
         )
 
+    zellij_session = os.environ.get("WAKE_EP_ZELLIJ_SESSION", "")
+    if wake_ep_enabled and invoke_method == "zellij" and not zellij_session:
+        raise ValueError(
+            "WAKE_EP_ZELLIJ_SESSION required when WAKE_EP_INVOKE_METHOD is 'zellij'. "
+            "Set it to a zellij session name (e.g. 'codex')."
+        )
+
     private_key_path_env = os.environ.get("AGENT_PRIVATE_KEY_PATH", "")
     private_key_path = Path(private_key_path_env) if private_key_path_env else None
 
@@ -172,5 +183,6 @@ def load_config_from_env() -> ServerConfig:
                 os.environ.get("WAKE_EP_SESSION_TIMEOUT", "30")
             ),
             tmux_target=tmux_target,
+            zellij_session=zellij_session,
         ),
     )

--- a/src/server/invoke_zellij.py
+++ b/src/server/invoke_zellij.py
@@ -1,0 +1,148 @@
+"""Zellij invocation strategy.
+
+Sends a notification string into a running zellij session via
+``zellij action write-chars`` followed by ``zellij action send-keys
+Enter``.  This is the zellij peer to ``invoke_tmux``: a simple IPC
+mechanism -- no SDK, no AI relay, just format a string and deliver it
+into the focused pane of the named zellij session.
+
+argv shape (verified against zellij 0.45.0
+``zellij-utils/src/cli.rs::CliAction``):
+
+  * write-chars: ``zellij --session SESSION action write-chars TEXT``
+  * send-keys:   ``zellij --session SESSION action send-keys "Enter"``
+
+The forcing-function semantics mirror tmux ``send-keys``: bytes go
+into the focused pane's PTY master via the same code path real
+keyboard input takes.  Empirical TUI-layer verification under Codex
+CLI is deferred to Phase 0.C of the web-codex-user-ideoon project.
+"""
+
+import asyncio
+import logging
+from dataclasses import dataclass
+
+logger = logging.getLogger(__name__)
+
+# Match invoke_tmux: 5s per-subprocess timeout so a stuck zellij CLI
+# call cannot wedge the wake lock indefinitely.  Exposed for tests.
+_SUBPROCESS_TIMEOUT: float = 5.0
+
+
+@dataclass(frozen=True)
+class ZellijInvokeConfig:
+    """Configuration for the zellij invoke method.
+
+    Attributes:
+        zellij_session: The zellij session name (passed via ``--session``).
+            The pane is the focused pane of that session; per-pane
+            targeting via ``--pane-id`` is not exposed here.
+    """
+
+    zellij_session: str
+
+
+def _format_notification(payload: dict) -> str:
+    """Build a one-line notification string from a wake payload.
+
+    Identical shape to ``invoke_tmux._format_notification`` so both
+    invokers produce the same on-screen text for the same payload.
+    """
+    sender = payload.get("sender_id", "unknown")
+    return f"Wake: new message from {sender}. Read and process."
+
+
+async def _run_zellij(args: tuple[str, ...], session: str, step: str) -> None:
+    """Run a single ``zellij --session ... action ...`` subprocess.
+
+    Wraps ``communicate()`` in ``asyncio.wait_for`` so a hung zellij
+    CLI invocation cannot hold the wake lock forever.  On non-zero
+    exit OR timeout, raises ``RuntimeError``.
+
+    Args:
+        args: positional argv after ``zellij --session SESSION action``.
+        session: zellij session name (for the error message only -- the
+            session is already in ``args[0]`` upstream).
+        step: human-readable step name used in error messages
+            (``"write-chars"`` or ``"send-keys"``).
+    """
+    proc = await asyncio.create_subprocess_exec(
+        *args,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    try:
+        _, stderr_bytes = await asyncio.wait_for(
+            proc.communicate(), timeout=_SUBPROCESS_TIMEOUT
+        )
+    except asyncio.TimeoutError:
+        try:
+            proc.kill()
+        except ProcessLookupError:
+            pass
+        raise RuntimeError(
+            f"zellij {step} timed out after {_SUBPROCESS_TIMEOUT}s "
+            f"(session={session!r})"
+        )
+    if proc.returncode != 0:
+        err_msg = stderr_bytes.decode().strip() if stderr_bytes else "unknown error"
+        raise RuntimeError(f"zellij {step} failed (exit {proc.returncode}): {err_msg}")
+
+
+async def invoke_zellij(payload: dict, config: ZellijInvokeConfig) -> None:
+    """Send a notification into a zellij session.
+
+    Two separate ``create_subprocess_exec`` calls with a 0.5s sleep
+    between them.  The first writes the notification text; the second
+    submits Enter.  Single-call combined delivery is unreliable (same
+    failure mode as tmux), so the two-step pattern is preserved here.
+
+    Args:
+        payload: The wake payload with message metadata.
+        config: Zellij configuration (session name).
+
+    Raises:
+        RuntimeError: If either zellij command fails (non-zero exit
+            code, missing binary, or 5s timeout).
+    """
+    notification = _format_notification(payload)
+    logger.info(
+        "Sending zellij notification to session=%s",
+        config.zellij_session,
+    )
+
+    session = config.zellij_session
+
+    # Step 1: write the notification text into the focused pane
+    await _run_zellij(
+        (
+            "zellij",
+            "--session",
+            session,
+            "action",
+            "write-chars",
+            notification,
+        ),
+        session=session,
+        step="write-chars",
+    )
+
+    # Step 2: wait for zellij to process the text (mirror tmux 0.5s)
+    await asyncio.sleep(0.5)
+
+    # Step 3: submit Enter via send-keys (key tokens space-separated;
+    # "Enter" is the documented spelling per cli.rs::SendKeys)
+    await _run_zellij(
+        (
+            "zellij",
+            "--session",
+            session,
+            "action",
+            "send-keys",
+            "Enter",
+        ),
+        session=session,
+        step="send-keys",
+    )
+
+    logger.info("Zellij notification sent successfully")

--- a/src/server/invoker.py
+++ b/src/server/invoker.py
@@ -1,12 +1,14 @@
 """Pluggable agent invocation strategies for the wake endpoint."""
+
 import logging
 from typing import Optional
 
 from src.server.invoke_tmux import TmuxInvokeConfig
+from src.server.invoke_zellij import ZellijInvokeConfig
 
 logger = logging.getLogger(__name__)
 
-_VALID_METHODS = ("noop", "tmux")
+_VALID_METHODS = ("noop", "tmux", "zellij")
 
 
 class AgentInvoker:
@@ -14,6 +16,8 @@ class AgentInvoker:
 
     The invocation method is determined by ``method``:
       - ``"tmux"``: send notification into a tmux session via send-keys
+      - ``"zellij"``: send notification into a zellij session via
+        ``write-chars`` + ``send-keys "Enter"``
       - ``"noop"``: do nothing (for testing / dry-run)
     """
 
@@ -21,6 +25,7 @@ class AgentInvoker:
         self,
         method: str,
         tmux_config: Optional[TmuxInvokeConfig] = None,
+        zellij_config: Optional[ZellijInvokeConfig] = None,
     ) -> None:
         if method not in _VALID_METHODS:
             raise ValueError(
@@ -33,8 +38,15 @@ class AgentInvoker:
                     "tmux_config required for method 'tmux'. "
                     "Set WAKE_EP_TMUX_TARGET to a tmux session target."
                 )
+        if method == "zellij":
+            if zellij_config is None:
+                raise ValueError(
+                    "zellij_config required for method 'zellij'. "
+                    "Set WAKE_EP_ZELLIJ_SESSION to a zellij session name."
+                )
         self._method = method
         self._tmux_config = tmux_config
+        self._zellij_config = zellij_config
 
     @property
     def method(self) -> str:
@@ -47,16 +59,19 @@ class AgentInvoker:
 
         Args:
             payload: The wake payload with message metadata.
-            resume: Reserved for future use (ignored by tmux/noop).
+            resume: Reserved for future use (ignored by all methods).
 
         Returns:
-            None for both tmux and noop methods.
+            None for tmux, zellij, and noop methods.
         """
         if self._method == "noop":
             logger.info("noop invoker: skipping invocation")
             return None
         if self._method == "tmux":
             await self._invoke_tmux(payload)
+            return None
+        if self._method == "zellij":
+            await self._invoke_zellij(payload)
             return None
         return None
 
@@ -68,3 +83,12 @@ class AgentInvoker:
             raise RuntimeError("tmux_config is None but method is 'tmux'")
 
         await invoke_tmux(payload, self._tmux_config)
+
+    async def _invoke_zellij(self, payload: dict) -> None:
+        """Send notification into a zellij session via write-chars + send-keys."""
+        from src.server.invoke_zellij import invoke_zellij
+
+        if self._zellij_config is None:
+            raise RuntimeError("zellij_config is None but method is 'zellij'")
+
+        await invoke_zellij(payload, self._zellij_config)

--- a/tests/test_invoke_zellij.py
+++ b/tests/test_invoke_zellij.py
@@ -1,0 +1,430 @@
+"""Tests for the zellij invoke method (subprocess-based, no SDK).
+
+Mirrors ``tests/test_invoke_tmux.py`` -- same structure, same coverage
+shape, plus the subprocess-timeout case that ``invoke_zellij`` adds
+relative to the simpler ``invoke_tmux`` (zellij goes through the
+``_run_zellij`` helper which wraps ``communicate()`` in
+``asyncio.wait_for``).
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.server.config import WakeEndpointConfig
+from src.server.invoke_zellij import (
+    ZellijInvokeConfig,
+    _format_notification,
+    invoke_zellij,
+)
+from src.server.invoker import _VALID_METHODS, AgentInvoker
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _wake_payload(
+    message_id: str = "550e8400-e29b-41d4-a716-446655440000",
+    swarm_id: str = "660e8400-e29b-41d4-a716-446655440001",
+    sender_id: str = "sender-agent-123",
+    notification_level: str = "normal",
+) -> dict:
+    return {
+        "message_id": message_id,
+        "swarm_id": swarm_id,
+        "sender_id": sender_id,
+        "notification_level": notification_level,
+    }
+
+
+def _mock_process(returncode: int = 0, stderr: bytes = b"") -> MagicMock:
+    """Create a mock async subprocess with communicate()."""
+    proc = MagicMock()
+    proc.returncode = returncode
+    proc.communicate = AsyncMock(return_value=(b"", stderr))
+    proc.kill = MagicMock()
+    return proc
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: ZellijInvokeConfig
+# ---------------------------------------------------------------------------
+
+
+class TestZellijInvokeConfig:
+    def test_requires_zellij_session(self) -> None:
+        cfg = ZellijInvokeConfig(zellij_session="codex")
+        assert cfg.zellij_session == "codex"
+
+    def test_frozen(self) -> None:
+        cfg = ZellijInvokeConfig(zellij_session="codex")
+        with pytest.raises(AttributeError):
+            cfg.zellij_session = "other"  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: _format_notification
+# ---------------------------------------------------------------------------
+
+
+class TestFormatNotification:
+    def test_includes_sender(self) -> None:
+        msg = _format_notification(_wake_payload())
+        assert "sender-agent-123" in msg
+
+    def test_defaults_for_missing_sender(self) -> None:
+        msg = _format_notification({})
+        assert "unknown" in msg
+
+    def test_is_single_line(self) -> None:
+        msg = _format_notification(_wake_payload())
+        assert "\n" not in msg
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: invoke_zellij (two separate exec calls)
+# ---------------------------------------------------------------------------
+
+
+class TestInvokeZellij:
+    @pytest.mark.asyncio
+    async def test_calls_zellij_two_step(self) -> None:
+        """Verifies two separate create_subprocess_exec calls."""
+        write_proc = _mock_process(returncode=0)
+        send_proc = _mock_process(returncode=0)
+        cfg = ZellijInvokeConfig(zellij_session="codex")
+        with (
+            patch(
+                "src.server.invoke_zellij.asyncio.create_subprocess_exec",
+                side_effect=[write_proc, send_proc],
+            ) as mock_exec,
+            patch(
+                "src.server.invoke_zellij.asyncio.sleep",
+                new_callable=AsyncMock,
+            ) as mock_sleep,
+        ):
+            await invoke_zellij(_wake_payload(), cfg)
+
+        assert mock_exec.call_count == 2
+        # First call: write-chars TEXT
+        write_call = mock_exec.call_args_list[0]
+        assert write_call[0][0] == "zellij"
+        assert write_call[0][1] == "--session"
+        assert write_call[0][2] == "codex"
+        assert write_call[0][3] == "action"
+        assert write_call[0][4] == "write-chars"
+        assert "sender-agent-123" in write_call[0][5]
+        # Second call: send-keys "Enter"
+        send_call = mock_exec.call_args_list[1]
+        assert send_call[0] == (
+            "zellij",
+            "--session",
+            "codex",
+            "action",
+            "send-keys",
+            "Enter",
+        )
+        # Sleep between the two calls
+        mock_sleep.assert_called_once_with(0.5)
+
+    @pytest.mark.asyncio
+    async def test_returns_none(self) -> None:
+        """invoke_zellij returns None (no session_id)."""
+        cfg = ZellijInvokeConfig(zellij_session="codex")
+        with (
+            patch(
+                "src.server.invoke_zellij.asyncio.create_subprocess_exec",
+                side_effect=[_mock_process(0), _mock_process(0)],
+            ),
+            patch(
+                "src.server.invoke_zellij.asyncio.sleep",
+                new_callable=AsyncMock,
+            ),
+        ):
+            result = await invoke_zellij(_wake_payload(), cfg)
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_raises_on_write_chars_failure(self) -> None:
+        """Non-zero exit from write-chars raises RuntimeError."""
+        write_proc = _mock_process(
+            returncode=1,
+            stderr=b"session not found: codex",
+        )
+        cfg = ZellijInvokeConfig(zellij_session="codex")
+        with patch(
+            "src.server.invoke_zellij.asyncio.create_subprocess_exec",
+            side_effect=[write_proc],
+        ):
+            with pytest.raises(RuntimeError, match="zellij write-chars failed"):
+                await invoke_zellij(_wake_payload(), cfg)
+
+    @pytest.mark.asyncio
+    async def test_raises_on_send_keys_failure(self) -> None:
+        """Non-zero exit from send-keys raises RuntimeError."""
+        write_proc = _mock_process(returncode=0)
+        send_proc = _mock_process(returncode=1, stderr=b"no server running")
+        cfg = ZellijInvokeConfig(zellij_session="codex")
+        with (
+            patch(
+                "src.server.invoke_zellij.asyncio.create_subprocess_exec",
+                side_effect=[write_proc, send_proc],
+            ),
+            patch(
+                "src.server.invoke_zellij.asyncio.sleep",
+                new_callable=AsyncMock,
+            ),
+        ):
+            with pytest.raises(RuntimeError, match="zellij send-keys failed"):
+                await invoke_zellij(_wake_payload(), cfg)
+
+    @pytest.mark.asyncio
+    async def test_error_message_includes_stderr(self) -> None:
+        """RuntimeError includes stderr content from the failing call."""
+        write_proc = _mock_process(returncode=1, stderr=b"no server running")
+        cfg = ZellijInvokeConfig(zellij_session="codex")
+        with patch(
+            "src.server.invoke_zellij.asyncio.create_subprocess_exec",
+            side_effect=[write_proc],
+        ):
+            with pytest.raises(RuntimeError, match="no server running"):
+                await invoke_zellij(_wake_payload(), cfg)
+
+    @pytest.mark.asyncio
+    async def test_custom_session(self) -> None:
+        """Zellij session from config is passed to both subprocess calls."""
+        write_proc = _mock_process(returncode=0)
+        send_proc = _mock_process(returncode=0)
+        cfg = ZellijInvokeConfig(zellij_session="orchestrator")
+        with (
+            patch(
+                "src.server.invoke_zellij.asyncio.create_subprocess_exec",
+                side_effect=[write_proc, send_proc],
+            ) as mock_exec,
+            patch(
+                "src.server.invoke_zellij.asyncio.sleep",
+                new_callable=AsyncMock,
+            ),
+        ):
+            await invoke_zellij(_wake_payload(), cfg)
+
+        write_call = mock_exec.call_args_list[0]
+        assert write_call[0][2] == "orchestrator"
+        send_call = mock_exec.call_args_list[1]
+        assert send_call[0][2] == "orchestrator"
+
+    @pytest.mark.asyncio
+    async def test_uses_exec_not_shell(self) -> None:
+        """create_subprocess_exec is used, not create_subprocess_shell."""
+        write_proc = _mock_process(returncode=0)
+        send_proc = _mock_process(returncode=0)
+        cfg = ZellijInvokeConfig(zellij_session="codex")
+        with (
+            patch(
+                "src.server.invoke_zellij.asyncio.create_subprocess_exec",
+                side_effect=[write_proc, send_proc],
+            ) as mock_exec,
+            patch(
+                "src.server.invoke_zellij.asyncio.sleep",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "src.server.invoke_zellij.asyncio.create_subprocess_shell",
+            ) as mock_shell,
+        ):
+            await invoke_zellij(_wake_payload(), cfg)
+
+        assert mock_exec.call_count == 2
+        mock_shell.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_sleep_between_calls(self) -> None:
+        """asyncio.sleep(0.5) is called between the two exec calls."""
+        write_proc = _mock_process(returncode=0)
+        send_proc = _mock_process(returncode=0)
+        cfg = ZellijInvokeConfig(zellij_session="codex")
+        call_order: list[str] = []
+
+        async def track_exec(*args: object, **kwargs: object) -> MagicMock:
+            call_order.append("exec")
+            if len(call_order) == 1:
+                return write_proc
+            return send_proc
+
+        async def track_sleep(seconds: float) -> None:
+            call_order.append(f"sleep:{seconds}")
+
+        with (
+            patch(
+                "src.server.invoke_zellij.asyncio.create_subprocess_exec",
+                side_effect=track_exec,
+            ),
+            patch(
+                "src.server.invoke_zellij.asyncio.sleep",
+                side_effect=track_sleep,
+            ),
+        ):
+            await invoke_zellij(_wake_payload(), cfg)
+
+        assert call_order == ["exec", "sleep:0.5", "exec"]
+
+    @pytest.mark.asyncio
+    async def test_subprocess_timeout_kills_and_raises(self) -> None:
+        """Hung zellij call raises RuntimeError and kill() is invoked."""
+        # communicate() never resolves -- raise asyncio.TimeoutError on
+        # the wait_for wrapping it
+        write_proc = MagicMock()
+        write_proc.communicate = AsyncMock(side_effect=asyncio.TimeoutError())
+        write_proc.kill = MagicMock()
+        cfg = ZellijInvokeConfig(zellij_session="codex")
+        with (
+            patch(
+                "src.server.invoke_zellij.asyncio.create_subprocess_exec",
+                side_effect=[write_proc],
+            ),
+            patch(
+                "src.server.invoke_zellij.asyncio.wait_for",
+                side_effect=asyncio.TimeoutError(),
+            ),
+        ):
+            with pytest.raises(RuntimeError, match="timed out"):
+                await invoke_zellij(_wake_payload(), cfg)
+        write_proc.kill.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: AgentInvoker with zellij method
+# ---------------------------------------------------------------------------
+
+
+class TestAgentInvokerZellij:
+    def test_zellij_in_valid_methods(self) -> None:
+        """zellij is in the _VALID_METHODS whitelist."""
+        assert "zellij" in _VALID_METHODS
+
+    def test_zellij_method_accepted(self) -> None:
+        """Zellij method is accepted (no SDK required)."""
+        cfg = ZellijInvokeConfig(zellij_session="codex")
+        invoker = AgentInvoker(method="zellij", zellij_config=cfg)
+        assert invoker.method == "zellij"
+
+    def test_zellij_rejects_missing_config(self) -> None:
+        """Zellij method raises if zellij_config is not provided."""
+        with pytest.raises(ValueError, match="zellij_config required"):
+            AgentInvoker(method="zellij")
+
+    def test_unknown_method_lists_zellij_in_error(self) -> None:
+        """Unknown method error message lists zellij as a valid option."""
+        with pytest.raises(ValueError, match="zellij"):
+            AgentInvoker(method="bogus")
+
+    @pytest.mark.asyncio
+    async def test_zellij_invoke_calls_invoke_zellij(self) -> None:
+        """AgentInvoker.invoke delegates to invoke_zellij."""
+        cfg = ZellijInvokeConfig(zellij_session="codex")
+        invoker = AgentInvoker(method="zellij", zellij_config=cfg)
+        with patch(
+            "src.server.invoke_zellij.invoke_zellij",
+            new_callable=AsyncMock,
+        ) as mock:
+            result = await invoker.invoke(_wake_payload())
+        mock.assert_called_once_with(_wake_payload(), cfg)
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_zellij_invoke_dispatch_wired(self) -> None:
+        """Whitelist + dispatch are both wired (no KeyError at invoke).
+
+        Defensive test against the brief's CRITICAL note: adding to
+        _VALID_METHODS without wiring the dispatch would let
+        ``method='zellij'`` pass init but raise at invoke time.
+        """
+        cfg = ZellijInvokeConfig(zellij_session="codex")
+        invoker = AgentInvoker(method="zellij", zellij_config=cfg)
+        # invoke() must not raise KeyError / NotImplementedError --
+        # it must reach _invoke_zellij and dispatch to the function.
+        with patch(
+            "src.server.invoke_zellij.invoke_zellij",
+            new_callable=AsyncMock,
+        ):
+            result = await invoker.invoke(_wake_payload())
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: WakeEndpointConfig zellij_session field
+# ---------------------------------------------------------------------------
+
+
+class TestWakeEndpointConfigZellij:
+    def test_zellij_session_default_empty(self) -> None:
+        cfg = WakeEndpointConfig()
+        assert cfg.zellij_session == ""
+
+    def test_zellij_session_custom(self) -> None:
+        cfg = WakeEndpointConfig(
+            enabled=True,
+            invoke_method="zellij",
+            zellij_session="codex",
+        )
+        assert cfg.zellij_session == "codex"
+        assert cfg.invoke_method == "zellij"
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: config validation for zellij method
+# ---------------------------------------------------------------------------
+
+
+class TestConfigZellijValidation:
+    def test_missing_zellij_session_raises(self) -> None:
+        """load_config_from_env raises if zellij method lacks WAKE_EP_ZELLIJ_SESSION."""
+        from src.server.config import load_config_from_env
+
+        env = {
+            "AGENT_ID": "test",
+            "AGENT_ENDPOINT": "https://test.example.com",
+            "AGENT_PUBLIC_KEY": "dGVzdA==",
+            "WAKE_EP_INVOKE_METHOD": "zellij",
+            "WAKE_EP_ZELLIJ_SESSION": "",
+        }
+        with patch.dict("os.environ", env, clear=True):
+            with pytest.raises(ValueError, match="WAKE_EP_ZELLIJ_SESSION"):
+                load_config_from_env()
+
+    def test_zellij_session_set_succeeds(self) -> None:
+        """load_config_from_env succeeds when zellij_session is set."""
+        from src.server.config import load_config_from_env
+
+        env = {
+            "AGENT_ID": "test",
+            "AGENT_ENDPOINT": "https://test.example.com",
+            "AGENT_PUBLIC_KEY": "dGVzdA==",
+            "WAKE_EP_INVOKE_METHOD": "zellij",
+            "WAKE_EP_ZELLIJ_SESSION": "codex",
+        }
+        with patch.dict("os.environ", env, clear=True):
+            config = load_config_from_env()
+        assert config.wake_endpoint.zellij_session == "codex"
+        assert config.wake_endpoint.invoke_method == "zellij"
+
+    def test_zellij_endpoint_disabled_skips_validation(self) -> None:
+        """Disabled wake endpoint with method=zellij does not require session."""
+        from src.server.config import load_config_from_env
+
+        env = {
+            "AGENT_ID": "test",
+            "AGENT_ENDPOINT": "https://test.example.com",
+            "AGENT_PUBLIC_KEY": "dGVzdA==",
+            "WAKE_EP_ENABLED": "false",
+            "WAKE_EP_INVOKE_METHOD": "zellij",
+            "WAKE_EP_ZELLIJ_SESSION": "",
+        }
+        with patch.dict("os.environ", env, clear=True):
+            # Should not raise even with empty zellij_session, because
+            # endpoint is disabled
+            config = load_config_from_env()
+        assert config.wake_endpoint.enabled is False
+        assert config.wake_endpoint.invoke_method == "zellij"


### PR DESCRIPTION
## Summary

Add `WAKE_EP_INVOKE_METHOD=zellij` as an env-selectable peer to the existing tmux invoker. Default invocation method remains `noop` and default behavior is unchanged for tmux deployments.

## Why

Marco's office-staff VMs in `nexus-marbell/web-codex-user-ideoon` will run Codex CLI inside Zellij panes (not tmux). Without a Zellij invoker, those agents lose the wake forcing-function. This patch ships **default-off** until Phase 0.C empirically verifies Codex-CLI's TUI submits a user turn under Zellij-injected `write-chars` + `send-keys "Enter"` — that test runs on `agent-01` (185.203.41.164) when we have a Zellij-running VM.

Dan asked for it explicitly: *"patch swarm messenger while we wait, with a config or env setting for tmux or zellij with updates to switch the cli commands to use the zellij syntax if set."*

## What

Mirrors `invoke_tmux.py` exactly:

| File | Change |
|------|--------|
| `src/server/invoke_zellij.py` (new, ~150 LOC) | `ZellijInvokeConfig` dataclass + `invoke_zellij()` via two `asyncio.create_subprocess_exec` calls (`write-chars`, `asyncio.sleep(0.5)`, `send-keys "Enter"`). Per-subprocess 5s timeout via `asyncio.wait_for` so a hung zellij CLI call cannot wedge the wake lock. |
| `src/server/invoker.py` | `"zellij"` added to `_VALID_METHODS` **AND** dispatch wired in `invoke()`. Both paths covered by tests so the whitelist-without-dispatch failure mode (brief flagged as CRITICAL) is impossible. |
| `src/server/config.py` | `zellij_session` field on `WakeEndpointConfig` + `WAKE_EP_ZELLIJ_SESSION` env binding + validation guard parallel to the existing tmux guard. |
| `src/server/app.py` | `_build_invoker` parallel branch for `"zellij"`. |
| `.env.example` | Documents `WAKE_EP_ZELLIJ_SESSION` + updated `invoke_method` comment listing zellij as an option. |
| `tests/test_invoke_zellij.py` (new, ~430 LOC) | 25 tests parallel to the 18 existing tmux tests. |

## argv shape (sourced, not weight-filled)

Verified against zellij 0.45.0 `zellij-utils/src/cli.rs` at `/root/projects/web-codex-user-ideoon/zellij-utils/src/cli.rs`:

- `CliAction::WriteChars` (lines 727-733): `zellij --session SESSION action write-chars TEXT`
- `CliAction::SendKeys` (lines 741-750): `zellij --session SESSION action send-keys "Enter"` (key tokens space-separated; `"Enter"` is the documented spelling)

Forcing-function source-traced through `actions.rs:712 → route.rs:264 → screen.rs:6022 → tab/mod.rs:3037` — bytes go to PTY master via the same code path real keyboard input takes. Verified at code level; empirical TUI-layer test deferred to Phase 0.C.

## Test plan

- [x] 25 new tests in `tests/test_invoke_zellij.py` — all green
- [x] `_VALID_METHODS` whitelist accepts `"zellij"`
- [x] `AgentInvoker(method="zellij")` raises `ValueError` without `zellij_config`
- [x] `AgentInvoker(method="zellij", zellij_config=cfg).invoke()` dispatches to `invoke_zellij` (whitelist + dispatch both wired)
- [x] argv shape: `zellij --session SESSION action write-chars TEXT` then `... send-keys Enter`
- [x] Two-step pattern: `create_subprocess_exec` → `asyncio.sleep(0.5)` → `create_subprocess_exec`
- [x] Subprocess timeout test: hung `communicate()` raises `RuntimeError` and `proc.kill()` is invoked
- [x] Config validation: `WAKE_EP_INVOKE_METHOD=zellij` + empty `WAKE_EP_ZELLIJ_SESSION` → `ValueError`
- [x] Disabled wake endpoint (`WAKE_EP_ENABLED=false`) skips `zellij_session` validation
- [x] Existing 18 tmux tests still pass (regression check)
- [x] Full `tests/test_wake_endpoint.py` + `tests/test_server.py` + `tests/test_wake_trigger_wiring.py` pass
- [x] Full suite: **519 passed** locally with my patch
- [ ] Empirical end-to-end test against a real zellij session — **intentionally deferred to Phase 0.C** of the web-codex-user-ideoon project on `agent-01`

## Default behavior unchanged

`WAKE_EP_INVOKE_METHOD` defaults to `noop`. Existing tmux deployments (e.g., `nexus.marbell.com`) are not affected — they continue to use `WAKE_EP_INVOKE_METHOD=tmux` + `WAKE_EP_TMUX_TARGET=nexus`.

## Status

**PR up, default-off, awaits Phase 0.C empirical test before any default-flip is considered.** Per `delivery-completion-gate.md`: this is *not* shipped — it sits in the codebase as opt-in capability until the TUI-layer verification gate clears.

Default flip from tmux to zellij is a **separate decision** pending Phase 0.C sign-off, and is explicitly out of scope for this PR.

## Out of scope

- ACP (`/root/projects/active-context-protocol/`) — different repo, separate dispatch. Not touched.
- Default flip from tmux to zellij — separate decision pending Phase 0.C sign-off.
- Marco-VM project's NetBird / Phase-0.A work — orthogonal.

## Incidental findings (not fixed in this PR)

Per `fix-what-you-find.md`, fixes for code I touched:
- **None to report inside the wake/invoker/config surface.** The existing `invoke_tmux.py`, `invoker.py`, and config validation were all clean and well-shaped — the patch is a true mirror with zero defect-correction.

Out-of-scope failures observed but not fixed:
- `tests/cli/test_messages.py::TestMessagesValidation::test_messages_requires_swarm_id` and `tests/cli/test_messages.py::TestMessagesArchiveAll::test_archive_all_requires_swarm_id` fail on `upstream/main` (verified by stashing my patch and re-running). Exit-code mismatch (1 vs expected 2 / 3 vs expected 2). These are CLI-domain (`cli_agent` ownership) — different module than the wake/invoker/config surface this PR touches. Per `fix-what-you-find.md` "Out of scope" exception, flagging here so cli_agent can address independently rather than expanding this PR's scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)