### PR TITLE
fix(invoke_zellij): correct zellij version pin (v0.45.0 → v0.44.2)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -97,7 +97,7 @@ WAKE_EP_ENABLED=true
 #           WAKE_EP_ZELLIJ_SESSION). No SDK required. Empirical TUI-layer
 #           verification under Codex CLI is pending Phase 0.C of the
 #           web-codex-user-ideoon project; verified at the zellij CLI
-#           layer (zellij 0.45.0 cli.rs) against the same PTY code path
+#           layer (zellij v0.44.2 cli.rs) against the same PTY code path
 #           as real keyboard input.
 # - noop:   does nothing (safe default)
 WAKE_EP_INVOKE_METHOD=noop

--- a/src/server/invoke_zellij.py
+++ b/src/server/invoke_zellij.py
@@ -6,8 +6,10 @@ Enter``.  This is the zellij peer to ``invoke_tmux``: a simple IPC
 mechanism -- no SDK, no AI relay, just format a string and deliver it
 into the focused pane of the named zellij session.
 
-argv shape (verified against zellij 0.45.0
-``zellij-utils/src/cli.rs::CliAction``):
+argv shape (verified against zellij v0.44.2
+``zellij-utils/src/cli.rs::CliAction`` -- lines 728 ``WriteChars`` and
+742 ``SendKeys``; v0.44.2 is the latest release tag on the canonical
+``zellij-org/zellij`` repo as of 2026-05-08):
 
   * write-chars: ``zellij --session SESSION action write-chars TEXT``
   * send-keys:   ``zellij --session SESSION action send-keys "Enter"``


### PR DESCRIPTION
## Summary

Follow-up to merged PR #206. The patch cites zellij **v0.45.0** as source-of-truth for the argv shape, but that tag does not exist on the canonical `zellij-org/zellij` repo — latest release is **v0.44.2** (verified via `gh api repos/zellij-org/zellij/tags`). The argv shape itself is correct; only the version label is wrong.

This PR corrects:
- `src/server/invoke_zellij.py` module docstring — names v0.44.2 + cites the actual line numbers (728 `WriteChars`, 742 `SendKeys`)
- `.env.example` — `zellij 0.45.0 cli.rs` → `zellij v0.44.2 cli.rs`

No behavior change. The 25 `tests/test_invoke_zellij.py` tests still pass on this branch.

## Why it matters

Per `cognitive-override` / source-everything posture: the version pin is a provenance label that travels with the artifact. A wrong version label is a wrong provenance claim, even when the underlying argv shape is correct. The next reader who tries to verify against "0.45.0" will hit a 404 and either spend time chasing it or distrust the whole claim. Honest provenance keeps the audit cheap.

## Cross-reference

- Origin: PR #206 review, kelvin's swarm message to sage `270da9b0` 2026-05-08T19:18Z
- sage's review reply confirming the finding: swarm `651543f5` 2026-05-08T19:20Z (*"agree, the version pin in the docstring and .env.example should be corrected. Worth a follow-up commit."*)
- A separate issue tracks the orthogonal finding (timeout-and-kill backport from `_run_zellij` to `invoke_tmux`) — that's a behavior change, not a label correction, so it ships separately.

## Test plan

- [x] 25 zellij tests pass on this branch (`pytest tests/test_invoke_zellij.py -q`)
- [x] No source code change beyond docstrings + comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)