### PR TITLE
fix: redact bootstrap join token display

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -71,6 +71,14 @@ error() {
     exit 1
 }
 
+display_join_url() {
+    if [[ -n "${JOIN_URL:-}" ]]; then
+        echo "<provided>"
+    else
+        echo "<none>"
+    fi
+}
+
 step() {
     echo ""
     echo -e "${CYAN}${BOLD}--- $* ---${NC}"
@@ -147,7 +155,7 @@ echo "  Agent ID:       ${AGENT_ID}"
 echo "  Domain:         ${DOMAIN}"
 echo "  Endpoint:       ${AGENT_ENDPOINT}"
 echo "  Contact email:  ${CONTACT_EMAIL}"
-echo "  Join URL:       ${JOIN_URL:-<none>}"
+echo "  Join URL:       $(display_join_url)"
 echo "  Tmux target:    ${TMUX_TARGET}"
 echo "  Install dir:    ${INSTALL_DIR}"
 echo "  DB path:        ${DB_PATH}"
@@ -558,7 +566,7 @@ if [[ -n "$JOIN_URL" ]]; then
         info "Successfully joined swarm."
     else
         warn "Join failed. You can retry manually:"
-        warn "  ${VENV_DIR}/bin/swarm join --token \"${JOIN_URL}\""
+        warn "  ${VENV_DIR}/bin/swarm join --token \"<invite-url>\""
     fi
 else
     info "No join URL provided. Skipping swarm join."


### PR DESCRIPTION
## Summary

Redacts credential-bearing swarm join URLs from bootstrap terminal output.

## Issue

Closes #209

## Changes

- Adds `display_join_url()` to render join URL presence as `<provided>` or `<none>`.
- Uses the redacted display in the configuration summary.
- Replaces the failed-join manual retry hint with a placeholder invite URL.

## Testing

- `bash -n scripts/bootstrap.sh`
- `shellcheck -e SC1091 scripts/bootstrap.sh`
- `git diff --check`

`ruff check scripts/bootstrap.sh src tests` was attempted and is not applicable to this shell-only change: Ruff parses `scripts/bootstrap.sh` as Python, then also reports many pre-existing Python lint findings outside this diff.

## Checklist

- [x] Tests pass for the changed shell script
- [x] Docs updated or not needed
- [x] Linted and formatted for changed file
