### PR TITLE
docs: fix Angie Ubuntu apt source

### DIFF
--- a/docs/HOST-DEPLOYMENT.md
+++ b/docs/HOST-DEPLOYMENT.md
@@ -56,7 +56,7 @@ curl -fsSL https://angie.software/keys/angie-signing.gpg | \
     gpg --dearmor -o /usr/share/keyrings/angie-archive-keyring.gpg
 
 echo "deb [signed-by=/usr/share/keyrings/angie-archive-keyring.gpg] \
-    https://download.angie.software/angie/$(. /etc/os-release && echo $ID)/ \
+    https://download.angie.software/angie/$(. /etc/os-release && echo $ID)/$(. /etc/os-release && echo $VERSION_ID) \
     $(. /etc/os-release && echo $VERSION_CODENAME) main" | \
     sudo tee /etc/apt/sources.list.d/angie.list
 


### PR DESCRIPTION
## Summary

Fixes the Angie apt repository URL in the host deployment guide for Ubuntu 24.04 Noble.

## Issue

Closes #211

## Changes

- Adds `VERSION_ID` to the documented Angie apt source path so it matches the repository layout used successfully during host setup.

## Testing

- `git diff --check`
- Evaluated the documented source shape on Ubuntu 24.04: `https://download.angie.software/angie/ubuntu/24.04 noble main`
- Confirmed `https://download.angie.software/angie/ubuntu/24.04/dists/noble/Release` returns HTTP 200.

## Checklist

- [x] Tests pass for the documentation change
- [x] Docs updated
- [x] Linted and formatted for changed file
