### PR TITLE
fix: authenticate internal wake trigger

### DIFF
--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -54,17 +54,19 @@ invokes the agent. This endpoint is conditionally mounted; set
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
 | `WAKE_EP_ENABLED` | No | `true` | Mount the `/api/wake` endpoint. Accepts `1`, `true`, or `yes`. |
-| `WAKE_EP_INVOKE_METHOD` | No | `noop` | Agent invocation strategy: `tmux` or `noop` |
+| `WAKE_EP_INVOKE_METHOD` | No | `noop` | Agent invocation strategy: `tmux`, `zellij`, or `noop` |
 | `WAKE_EP_SECRET` | No | (empty) | Shared secret for `X-Wake-Secret` header authentication. Empty disables auth. |
 | `WAKE_EP_SESSION_FILE` | No | `/root/.swarm/session.json` | Path to session state file for invocation deduplication |
 | `WAKE_EP_SESSION_TIMEOUT` | No | `30` | Minutes before an active session is considered expired |
 | `WAKE_EP_TMUX_TARGET` | When method is `tmux` | - | Tmux session/window/pane target (e.g., `main:0`) |
+| `WAKE_EP_ZELLIJ_SESSION` | When method is `zellij` | - | Zellij session name (e.g., `codex`) |
 
 ### Invoke Methods
 
 | Method | Configuration | Behavior |
 |--------|---------------|----------|
 | `tmux` | `WAKE_EP_TMUX_TARGET` (required) | Sends notification into a running tmux session via `tmux send-keys`. |
+| `zellij` | `WAKE_EP_ZELLIJ_SESSION` (required) | Sends notification into a running zellij session via `zellij action write-chars`. |
 | `noop` | Not required | Does nothing. Useful for testing or dry-run. |
 
 ## Validation Rules
@@ -74,6 +76,7 @@ The server enforces these validation rules at startup:
 1. `AGENT_ID`, `AGENT_ENDPOINT`, and `AGENT_PUBLIC_KEY` are **always required**.
    The server will refuse to start without them.
 2. If `WAKE_EP_INVOKE_METHOD` is `tmux`, `WAKE_EP_TMUX_TARGET` is required.
+3. If `WAKE_EP_INVOKE_METHOD` is `zellij`, `WAKE_EP_ZELLIJ_SESSION` is required.
 
 ## Quick Start
 

--- a/src/claude/wake_trigger.py
+++ b/src/claude/wake_trigger.py
@@ -1,21 +1,26 @@
 """Wake trigger for Claude subagent activation."""
+
+import logging
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from enum import Enum
-from typing import Callable, Awaitable
-import logging
 
 import httpx
 
-from src.state import DatabaseManager, InboxMessage
-from src.claude.notification_preferences import NotificationPreferences, NotificationLevel
 from src.claude.context_loader import ContextLoader, SwarmContext
+from src.claude.notification_preferences import (
+    NotificationLevel,
+    NotificationPreferences,
+)
+from src.state import DatabaseManager, InboxMessage
 
 logger = logging.getLogger(__name__)
 
 
 class WakeDecision(Enum):
     """Decision on how to handle a message."""
+
     WAKE = "wake"
     QUEUE = "queue"
     SKIP = "skip"
@@ -24,6 +29,7 @@ class WakeDecision(Enum):
 @dataclass(frozen=True)
 class WakeEvent:
     """Event that may trigger a wake."""
+
     message: InboxMessage
     context: SwarmContext
     decision: WakeDecision
@@ -41,8 +47,12 @@ class WakeTrigger:
     """Triggers Claude subagent wake when messages arrive via POST to /api/wake."""
 
     def __init__(
-        self, db_manager: DatabaseManager, wake_endpoint: str,
-        preferences: NotificationPreferences, wake_timeout: float = 5.0,
+        self,
+        db_manager: DatabaseManager,
+        wake_endpoint: str,
+        preferences: NotificationPreferences,
+        wake_timeout: float = 5.0,
+        wake_secret: str = "",
     ) -> None:
         if not db_manager.is_initialized:
             raise WakeTriggerError("Database not initialized")
@@ -50,6 +60,7 @@ class WakeTrigger:
             raise WakeTriggerError("Wake endpoint required")
         self._db = db_manager
         self._wake_endpoint = wake_endpoint
+        self._wake_secret = wake_secret
         self._preferences = preferences
         self._wake_timeout = wake_timeout
         self._context_loader = ContextLoader(db_manager)
@@ -64,7 +75,12 @@ class WakeTrigger:
         context = await self._context_loader.load_context(message)
         decision = self._make_decision(context)
         level = self._get_notification_level(context)
-        event = WakeEvent(message=message, context=context, decision=decision, notification_level=level)
+        event = WakeEvent(
+            message=message,
+            context=context,
+            decision=decision,
+            notification_level=level,
+        )
         if decision == WakeDecision.WAKE:
             await self._trigger_wake(event)
         await self._notify_callbacks(event)
@@ -75,7 +91,11 @@ class WakeTrigger:
         if context.is_sender_muted or context.is_swarm_muted:
             return WakeDecision.SKIP
         level = self._get_notification_level(context)
-        return WakeDecision.QUEUE if level == NotificationLevel.SILENT else WakeDecision.WAKE
+        return (
+            WakeDecision.QUEUE
+            if level == NotificationLevel.SILENT
+            else WakeDecision.WAKE
+        )
 
     def _get_notification_level(self, context: SwarmContext) -> NotificationLevel:
         """Determine notification level from preferences and context."""
@@ -84,9 +104,12 @@ class WakeTrigger:
         is_high_priority = context.message.message_type == "high_priority"
         is_system = context.message.message_type == "system"
         return self._preferences.should_wake(
-            sender_id=context.message.sender_id, swarm_id=context.message.swarm_id,
-            content=context.message.content, is_direct_mention=is_direct,
-            is_high_priority=is_high_priority, is_system_message=is_system,
+            sender_id=context.message.sender_id,
+            swarm_id=context.message.swarm_id,
+            content=context.message.content,
+            is_direct_mention=is_direct,
+            is_high_priority=is_high_priority,
+            is_system_message=is_system,
             current_hour=current_hour,
         )
 
@@ -98,14 +121,26 @@ class WakeTrigger:
         details.
         """
         payload = {
-            "message_id": event.message.message_id, "swarm_id": event.message.swarm_id,
-            "sender_id": event.message.sender_id, "notification_level": event.notification_level.name.lower(),
+            "message_id": event.message.message_id,
+            "swarm_id": event.message.swarm_id,
+            "sender_id": event.message.sender_id,
+            "notification_level": event.notification_level.name.lower(),
         }
+        headers = {}
+        if self._wake_secret:
+            headers["X-Wake-Secret"] = self._wake_secret
         try:
             async with httpx.AsyncClient(timeout=self._wake_timeout) as client:
-                response = await client.post(self._wake_endpoint, json=payload)
+                response = await client.post(
+                    self._wake_endpoint,
+                    json=payload,
+                    headers=headers,
+                )
                 if response.status_code >= 400:
-                    raise WakeTriggerError(f"Wake endpoint returned {response.status_code}: {response.text}")
+                    raise WakeTriggerError(
+                        "Wake endpoint returned "
+                        f"{response.status_code}: {response.text}"
+                    )
         except httpx.HTTPError as exc:
             raise WakeTriggerError(
                 f"Wake endpoint unreachable at {self._wake_endpoint}: {exc}"

--- a/src/server/app.py
+++ b/src/server/app.py
@@ -1,4 +1,5 @@
 """FastAPI application factory."""
+
 import logging
 from contextlib import asynccontextmanager
 from pathlib import Path
@@ -51,6 +52,7 @@ def _build_wake_trigger(
         wake_endpoint=config.wake.endpoint,
         preferences=NotificationPreferences(),
         wake_timeout=config.wake.timeout,
+        wake_secret=config.wake_endpoint.secret,
     )
 
 
@@ -93,7 +95,8 @@ def create_app(config: Optional[ServerConfig] = None) -> FastAPI:
         wake_trigger = _build_wake_trigger(config, db_manager)
         if wake_trigger is not None:
             logger.info(
-                "WakeTrigger active, endpoint=%s", config.wake.endpoint,
+                "WakeTrigger active, endpoint=%s",
+                config.wake.endpoint,
             )
         else:
             logger.info("WakeTrigger disabled")
@@ -109,7 +112,9 @@ def create_app(config: Optional[ServerConfig] = None) -> FastAPI:
         lifespan=lifespan,
     )
     app.add_middleware(RequestLoggingMiddleware)
-    app.add_middleware(RateLimitMiddleware, requests_per_minute=config.rate_limit.messages_per_minute)
+    app.add_middleware(
+        RateLimitMiddleware, requests_per_minute=config.rate_limit.messages_per_minute
+    )
     app.add_exception_handler(ValidationError, _validation_error_handler)
     app.include_router(create_message_router(db_manager, config.agent.agent_id))
     app.include_router(create_join_router(config, db_manager))
@@ -135,7 +140,8 @@ def create_app(config: Optional[ServerConfig] = None) -> FastAPI:
             )
         )
         logger.info(
-            "Wake endpoint active, method=%s", config.wake_endpoint.invoke_method,
+            "Wake endpoint active, method=%s",
+            config.wake_endpoint.invoke_method,
         )
     else:
         logger.info("Wake endpoint disabled")
@@ -143,6 +149,14 @@ def create_app(config: Optional[ServerConfig] = None) -> FastAPI:
     return app
 
 
-async def _validation_error_handler(request: Request, exc: ValidationError) -> JSONResponse:
-    response = ErrorResponse(error=ErrorDetail(code="INVALID_FORMAT", message="Request validation failed", details={"validation_errors": exc.errors()}))
+async def _validation_error_handler(
+    request: Request, exc: ValidationError
+) -> JSONResponse:
+    response = ErrorResponse(
+        error=ErrorDetail(
+            code="INVALID_FORMAT",
+            message="Request validation failed",
+            details={"validation_errors": exc.errors()},
+        )
+    )
     return JSONResponse(status_code=400, content=response.model_dump())

--- a/tests/claude/test_wake_trigger.py
+++ b/tests/claude/test_wake_trigger.py
@@ -1,21 +1,24 @@
 """Tests for wake trigger."""
-import pytest
+
 from datetime import datetime, timezone
 from pathlib import Path
 from unittest.mock import AsyncMock, patch
-from src.state import DatabaseManager
-from src.state.models.inbox import InboxMessage, InboxStatus
-from src.claude.wake_trigger import (
-    WakeTrigger,
-    WakeDecision,
-    WakeEvent,
-    WakeTriggerError,
-)
+
+import pytest
+
 from src.claude.notification_preferences import (
-    NotificationPreferences,
     NotificationLevel,
+    NotificationPreferences,
     WakeCondition,
 )
+from src.claude.wake_trigger import (
+    WakeDecision,
+    WakeEvent,
+    WakeTrigger,
+    WakeTriggerError,
+)
+from src.state import DatabaseManager
+from src.state.models.inbox import InboxMessage, InboxStatus
 
 
 class TestWakeTrigger:
@@ -53,9 +56,7 @@ class TestWakeTrigger:
         """Uninitialized database should raise error."""
         db = DatabaseManager(tmp_path / "test.db")
         with pytest.raises(WakeTriggerError, match="Database not initialized"):
-            WakeTrigger(
-                db, "http://localhost:8080/api/wake", NotificationPreferences()
-            )
+            WakeTrigger(db, "http://localhost:8080/api/wake", NotificationPreferences())
 
     def test_empty_endpoint_raises(self, db_manager: DatabaseManager) -> None:
         """Empty wake endpoint should raise error."""
@@ -74,9 +75,7 @@ class TestWakeTrigger:
             mock_instance = AsyncMock()
             mock_instance.__aenter__.return_value = mock_instance
             mock_instance.__aexit__.return_value = None
-            mock_instance.post.return_value = AsyncMock(
-                status_code=200, text=""
-            )
+            mock_instance.post.return_value = AsyncMock(status_code=200, text="")
             mock_client.return_value = mock_instance
 
             trigger = WakeTrigger(
@@ -140,9 +139,7 @@ class TestWakeTrigger:
         prefs = NotificationPreferences(
             enabled=False,  # Disabled returns SILENT
         )
-        trigger = WakeTrigger(
-            db_manager, "http://localhost:8080/api/wake", prefs
-        )
+        trigger = WakeTrigger(db_manager, "http://localhost:8080/api/wake", prefs)
         event = await trigger.process_message(sample_message)
 
         assert event.decision == WakeDecision.QUEUE
@@ -203,6 +200,35 @@ class TestWakeTrigger:
             call_args = mock_instance.post.call_args
             assert call_args[0][0] == "http://localhost:8080/api/wake"
             assert "message_id" in call_args[1]["json"]
+            assert call_args[1]["headers"] == {}
+
+    @pytest.mark.asyncio
+    async def test_wake_posts_secret_header_when_configured(
+        self,
+        db_manager: DatabaseManager,
+        sample_message: InboxMessage,
+        default_prefs: NotificationPreferences,
+    ) -> None:
+        """WAKE POST should include X-Wake-Secret when configured."""
+        with patch("src.claude.wake_trigger.httpx.AsyncClient") as mock_client:
+            mock_instance = AsyncMock()
+            mock_instance.__aenter__.return_value = mock_instance
+            mock_instance.__aexit__.return_value = None
+            mock_response = AsyncMock()
+            mock_response.status_code = 200
+            mock_instance.post.return_value = mock_response
+            mock_client.return_value = mock_instance
+
+            trigger = WakeTrigger(
+                db_manager,
+                "http://localhost:8080/api/wake",
+                default_prefs,
+                wake_secret="test-secret",
+            )
+            await trigger.process_message(sample_message)
+
+            call_args = mock_instance.post.call_args
+            assert call_args[1]["headers"] == {"X-Wake-Secret": "test-secret"}
 
     @pytest.mark.asyncio
     async def test_wake_endpoint_error_raises(

--- a/tests/test_wake_trigger_wiring.py
+++ b/tests/test_wake_trigger_wiring.py
@@ -1,18 +1,21 @@
 """Integration tests: WakeTrigger is called after message persistence."""
-import asyncio
-import json
-from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock, patch
 
-import pytest
+import asyncio
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
 from fastapi.testclient import TestClient
 
+from src.claude.wake_trigger import WakeTrigger
 from src.server.app import create_app
 from src.server.config import (
-    AgentConfig, RateLimitConfig, ServerConfig, WakeConfig, WakeEndpointConfig,
+    AgentConfig,
+    RateLimitConfig,
+    ServerConfig,
+    WakeConfig,
+    WakeEndpointConfig,
     _parse_bool,
 )
-from src.claude.wake_trigger import WakeDecision, WakeTrigger
 from src.state.database import DatabaseManager
 from src.state.repositories.inbox import InboxRepository
 
@@ -38,6 +41,30 @@ def _make_config(tmp_path: Path, wake_enabled: bool = False) -> ServerConfig:
             timeout=2.0,
         ),
         wake_endpoint=WakeEndpointConfig(enabled=False),
+    )
+
+
+def _make_secret_config(tmp_path: Path) -> ServerConfig:
+    """Build a ServerConfig with wake trigger and matching wake endpoint secret."""
+    return ServerConfig(
+        agent=AgentConfig(
+            agent_id="test-agent-001",
+            endpoint="https://test.example.com",
+            public_key="dGVzdC1wdWJsaWMta2V5LWJhc2U2NA==",
+            protocol_version="0.1.0",
+        ),
+        rate_limit=RateLimitConfig(messages_per_minute=100),
+        db_path=tmp_path / "wake-secret.db",
+        wake=WakeConfig(
+            enabled=True,
+            endpoint="http://localhost:9090/api/wake",
+            timeout=2.0,
+        ),
+        wake_endpoint=WakeEndpointConfig(
+            enabled=True,
+            invoke_method="noop",
+            secret="test-secret",
+        ),
     )
 
 
@@ -80,7 +107,8 @@ class TestWakeTriggerDisabled:
         assert response.json()["status"] == "queued"
 
     def test_no_wake_trigger_on_app_state_when_disabled(
-        self, tmp_path: Path,
+        self,
+        tmp_path: Path,
     ) -> None:
         """app.state.wake_trigger is None when wake is disabled."""
         config = _make_config(tmp_path, wake_enabled=False)
@@ -94,7 +122,8 @@ class TestWakeTriggerEnabled:
     """When wake trigger is enabled, it runs after message persistence."""
 
     def test_wake_trigger_initialized_on_app_state(
-        self, tmp_path: Path,
+        self,
+        tmp_path: Path,
     ) -> None:
         """app.state.wake_trigger is a WakeTrigger when enabled."""
         config = _make_config(tmp_path, wake_enabled=True)
@@ -113,7 +142,8 @@ class TestWakeTriggerEnabled:
             mock_instance.__aenter__.return_value = mock_instance
             mock_instance.__aexit__.return_value = None
             mock_instance.post.return_value = AsyncMock(
-                status_code=200, text="",
+                status_code=200,
+                text="",
             )
             mock_http.return_value = mock_instance
 
@@ -134,7 +164,8 @@ class TestWakeTriggerEnabled:
             assert call_url == "http://localhost:9090/api/wake"
 
     def test_wake_trigger_payload_contains_message_id(
-        self, tmp_path: Path,
+        self,
+        tmp_path: Path,
     ) -> None:
         """Wake POST payload includes the message_id from the received message."""
         config = _make_config(tmp_path, wake_enabled=True)
@@ -144,7 +175,8 @@ class TestWakeTriggerEnabled:
             mock_instance.__aenter__.return_value = mock_instance
             mock_instance.__aexit__.return_value = None
             mock_instance.post.return_value = AsyncMock(
-                status_code=200, text="",
+                status_code=200,
+                text="",
             )
             mock_http.return_value = mock_instance
 
@@ -162,8 +194,40 @@ class TestWakeTriggerEnabled:
             assert payload["swarm_id"] == msg["swarm_id"]
             assert payload["sender_id"] == msg["sender"]["agent_id"]
 
+    def test_wake_trigger_uses_configured_endpoint_secret(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """WakeTrigger POST includes the configured wake endpoint secret."""
+        config = _make_secret_config(tmp_path)
+
+        with patch("src.claude.wake_trigger.httpx.AsyncClient") as mock_http:
+            mock_instance = AsyncMock()
+            mock_instance.__aenter__.return_value = mock_instance
+            mock_instance.__aexit__.return_value = None
+            mock_instance.post.return_value = AsyncMock(
+                status_code=200,
+                text="",
+            )
+            mock_http.return_value = mock_instance
+
+            app = create_app(config)
+            msg = _valid_message()
+            with TestClient(app) as client:
+                response = client.post(
+                    "/swarm/message",
+                    json=msg,
+                    headers={"Content-Type": "application/json"},
+                )
+
+            assert response.status_code == 200
+            assert mock_instance.post.call_args[1]["headers"] == {
+                "X-Wake-Secret": "test-secret",
+            }
+
     def test_message_still_queued_on_wake_failure(
-        self, tmp_path: Path,
+        self,
+        tmp_path: Path,
     ) -> None:
         """Even if the wake endpoint fails, the message is still accepted."""
         config = _make_config(tmp_path, wake_enabled=True)
@@ -173,7 +237,8 @@ class TestWakeTriggerEnabled:
             mock_instance.__aenter__.return_value = mock_instance
             mock_instance.__aexit__.return_value = None
             mock_instance.post.return_value = AsyncMock(
-                status_code=500, text="Internal error",
+                status_code=500,
+                text="Internal error",
             )
             mock_http.return_value = mock_instance
 
@@ -191,7 +256,8 @@ class TestWakeTriggerEnabled:
             assert response.json()["status"] == "queued"
 
     def test_message_still_queued_on_unexpected_exception(
-        self, tmp_path: Path,
+        self,
+        tmp_path: Path,
     ) -> None:
         """Non-WakeTriggerError exceptions (e.g. ReadTimeout) are caught too."""
         config = _make_config(tmp_path, wake_enabled=True)
@@ -228,7 +294,8 @@ class TestWakeTriggerEnabled:
             mock_instance.__aenter__.return_value = mock_instance
             mock_instance.__aexit__.return_value = None
             mock_instance.post.return_value = AsyncMock(
-                status_code=200, text="",
+                status_code=200,
+                text="",
             )
             mock_http.return_value = mock_instance
 


### PR DESCRIPTION
## Summary

Allows the internal wake trigger to authenticate to a secret-protected `/api/wake` endpoint.

## Issue

Closes #213

## Changes

- Adds an optional `wake_secret` to `WakeTrigger`.
- Sends `X-Wake-Secret` on internal wake POSTs when configured.
- Wires `config.wake_endpoint.secret` into the wake trigger from `create_app()`.
- Documents the existing zellij wake endpoint variables in `docs/ENVIRONMENT.md`.
- Adds unit and integration coverage for the wake secret header.

## Testing

- `pytest tests/claude/test_wake_trigger.py tests/test_wake_trigger_wiring.py -q`
- `ruff check src/claude/wake_trigger.py tests/claude/test_wake_trigger.py tests/test_wake_trigger_wiring.py`
- `ruff check src/server/app.py --ignore E402,I001` (the module intentionally runs package integrity verification before later imports)
- `git diff --check`

## Checklist

- [x] Tests pass
- [x] Docs updated
- [x] Linted and formatted
