### PR TITLE
fix(server): include public_key in member_joined broadcast (#214)

### DIFF
--- a/src/server/broadcast.py
+++ b/src/server/broadcast.py
@@ -22,7 +22,7 @@ import json
 import logging
 import uuid
 from datetime import datetime, timezone
-from typing import Iterable
+from typing import Iterable, Optional
 
 import httpx
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
@@ -50,6 +50,7 @@ def build_broadcast_envelope(
     new_agent_id: str,
     new_agent_endpoint: str,
     joined_at: datetime,
+    new_agent_public_key: Optional[str] = None,
 ) -> dict:
     """Build a signed wire envelope for a master-side member_joined broadcast.
 
@@ -59,17 +60,25 @@ def build_broadcast_envelope(
     - ``type=system`` (real system event, NOT ``type=message`` wrapping
       system content — receiver dispatcher only fires on real system).
     - ``content`` is a JSON string carrying the lifecycle payload with
-      ``endpoint`` and ``joined_at`` populated (#199 — required for the
-      receiver to write all 5 NOT NULL ``swarm_members`` columns).
+      ``endpoint``, ``joined_at`` and ``public_key`` populated (#199,
+      #214 — required for the receiver to write all 5 NOT NULL
+      ``swarm_members`` columns directly from the broadcast, with no
+      network fetch of the new member's ``/swarm/info`` required).
     - ``signature`` signs the master's authority over the broadcast with
       the same canonical payload as ``client/operations.py``.
+
+    ``new_agent_public_key`` is optional only for backward compatibility
+    with callers that have not yet been updated; in production, callers
+    sourced from ``routes/join.py`` always pass it through. When omitted,
+    receivers running a post-#214 build will fall back to the legacy
+    ``/swarm/info`` fetch path.
     """
     message_id = uuid.uuid4()
     swarm_uuid = uuid.UUID(swarm_id)
     joined_at_iso = _format_timestamp(joined_at)
     now = datetime.now(timezone.utc)
 
-    content_payload = {
+    content_payload: dict = {
         "type": "system",
         "action": "member_joined",
         "swarm_id": swarm_id,
@@ -77,6 +86,8 @@ def build_broadcast_envelope(
         "endpoint": new_agent_endpoint,
         "joined_at": joined_at_iso,
     }
+    if new_agent_public_key is not None:
+        content_payload["public_key"] = new_agent_public_key
     content = json.dumps(content_payload)
 
     signature = sign_message(
@@ -107,14 +118,17 @@ async def broadcast_member_joined(
     master_private_key: Ed25519PrivateKey,
     new_agent_endpoint: str,
     joined_at: datetime,
+    new_agent_public_key: Optional[str] = None,
 ) -> tuple[int, int]:
     """Fan out the member_joined broadcast to every existing member.
 
     Per-member failures are logged and swallowed: the broadcast is
-    best-effort delivery, NOT atomic. A member that misses the event will
-    learn about the new agent via the lazy public-key fetch fallback in
-    the signature verifier, or via the next master-side broadcast if the
-    join is retried.
+    best-effort delivery, NOT atomic. When the broadcast carries the new
+    member's ``public_key`` inline (#214), receivers can populate
+    ``swarm_members`` directly with no network call. If the broadcast
+    omits ``public_key`` (legacy masters), receivers fall back to a
+    ``/swarm/info`` fetch — which is the brittle path that issue #214
+    was filed against.
 
     Returns ``(delivered, attempted)`` for caller-side observability.
     The new joiner and the master itself are skipped (they already have
@@ -128,6 +142,7 @@ async def broadcast_member_joined(
         new_agent_id=new_agent_id,
         new_agent_endpoint=new_agent_endpoint,
         joined_at=joined_at,
+        new_agent_public_key=new_agent_public_key,
     )
 
     targets = [

--- a/src/server/notifications.py
+++ b/src/server/notifications.py
@@ -32,10 +32,16 @@ class LifecycleAction(Enum):
 class LifecycleEvent:
     """A swarm lifecycle event to be recorded as a system notification.
 
-    For ``MEMBER_JOINED`` events, ``endpoint`` and ``joined_at`` SHOULD be
-    populated so receiver-side dispatchers (see ``system_dispatch.py``) can
-    write the new agent into ``swarm_members`` with the authoritative
-    master-side values rather than envelope fallbacks (#199).
+    For ``MEMBER_JOINED`` events, ``endpoint``, ``joined_at`` and
+    ``public_key`` SHOULD be populated so receiver-side dispatchers (see
+    ``system_dispatch.py``) can write the new agent into
+    ``swarm_members`` directly from the broadcast payload — no
+    network fetch of the new member's ``/swarm/info`` required (#214).
+
+    Background (#214): the master always knows the new member's public
+    key (it just stored the row via ``add_member``). Carrying the key in
+    the broadcast eliminates the fetch race that hit live peers when an
+    agent's public DNS A-record was still propagating at broadcast time.
     """
 
     action: LifecycleAction
@@ -45,6 +51,7 @@ class LifecycleEvent:
     reason: Optional[str] = None
     endpoint: Optional[str] = None
     joined_at: Optional[str] = None
+    public_key: Optional[str] = None
 
 
 def build_notification_message(event: LifecycleEvent) -> InboxMessage:
@@ -70,6 +77,8 @@ def build_notification_message(event: LifecycleEvent) -> InboxMessage:
         payload["endpoint"] = event.endpoint
     if event.joined_at is not None:
         payload["joined_at"] = event.joined_at
+    if event.public_key is not None:
+        payload["public_key"] = event.public_key
 
     content = json.dumps(payload)
     return InboxMessage(
@@ -118,6 +127,7 @@ async def notify_member_joined(
     agent_id: str,
     endpoint: Optional[str] = None,
     joined_at: Optional[str] = None,
+    public_key: Optional[str] = None,
 ) -> InboxMessage:
     """Record a member_joined notification on the local inbox.
 
@@ -125,9 +135,11 @@ async def notify_member_joined(
     own inbox. Cross-host delivery to existing members is handled
     separately by ``broadcast_member_joined`` in ``broadcast.py``.
 
-    ``endpoint`` and ``joined_at`` are passed into the payload (#199) so
-    the same ``LifecycleEvent`` shape can be reused for the cross-host
-    broadcast — receivers need both fields to populate ``swarm_members``.
+    ``endpoint``, ``joined_at`` and ``public_key`` are passed into the
+    payload (#199, #214) so the same ``LifecycleEvent`` shape can be
+    reused for the cross-host broadcast — receivers need all three
+    fields to populate ``swarm_members`` directly from the broadcast
+    without fetching ``/swarm/info`` (#214).
     """
     event = LifecycleEvent(
         action=LifecycleAction.MEMBER_JOINED,
@@ -135,6 +147,7 @@ async def notify_member_joined(
         agent_id=agent_id,
         endpoint=endpoint,
         joined_at=joined_at,
+        public_key=public_key,
     )
     return await persist_notification(db, event)
 

--- a/src/server/routes/join.py
+++ b/src/server/routes/join.py
@@ -135,6 +135,7 @@ def create_join_router(config: ServerConfig, db: DatabaseManager) -> APIRouter:
                     agent_id=body.sender.agent_id,
                     endpoint=body.sender.endpoint,
                     joined_at=joined_at_iso,
+                    public_key=body.sender.public_key,
                 )
             except Exception as exc:
                 logger.warning(
@@ -143,12 +144,15 @@ def create_join_router(config: ServerConfig, db: DatabaseManager) -> APIRouter:
                     exc,
                 )
 
-            # Cross-host fan-out (#200): inform every existing member so
-            # PR #198's receiver dispatcher can write the new agent into
-            # their local swarm_members table. Wrap the entire call in
-            # try/except as belt-and-suspenders — broadcast.py already
-            # swallows per-member failures, but a config or signing-time
-            # error must not block join acceptance.
+            # Cross-host fan-out (#200, #214): inform every existing
+            # member so the receiver dispatcher (PR #198) can write the
+            # new agent into their local swarm_members table. Carrying
+            # the new member's public_key inline (#214) eliminates the
+            # receiver-side /swarm/info fetch race that hit live peers
+            # when a CF A-record was still propagating at broadcast time.
+            # Wrap the entire call in try/except as belt-and-suspenders
+            # — broadcast.py already swallows per-member failures, but a
+            # config or signing-time error must not block join acceptance.
             master_private_key = _load_master_private_key(config)
             if master_private_key is not None:
                 try:
@@ -161,6 +165,7 @@ def create_join_router(config: ServerConfig, db: DatabaseManager) -> APIRouter:
                         master_private_key=master_private_key,
                         new_agent_endpoint=body.sender.endpoint,
                         joined_at=joined_at_dt,
+                        new_agent_public_key=body.sender.public_key,
                     )
                 except Exception as exc:
                     logger.warning(

--- a/src/server/system_dispatch.py
+++ b/src/server/system_dispatch.py
@@ -5,15 +5,26 @@ or member_kicked, the local swarm_members table must be updated so direct A2A
 sends can route. Without this dispatch, members can only reach a newly-joined
 agent via broadcast — direct sends fail silently on the sender side.
 
-Path 1b from issue #197: lazy-fetch /swarm/info on the new member's endpoint
-to retrieve the public_key, pull swarm_id from the message envelope, and
-INSERT OR IGNORE into swarm_members. INSERT OR REPLACE into public_keys to
-pre-warm the verification cache. Symmetric DELETE for member_left/member_kicked
-on swarm_members only — public_keys cache survives churn.
+#214 path (preferred): the broadcast payload carries the new member's
+``public_key`` inline. Receivers INSERT OR IGNORE into ``swarm_members`` and
+INSERT OR REPLACE into ``public_keys`` directly — no network call required.
+This is the master-authoritative path: the master just stored the new member
+via ``add_member`` and forwards the same key in the broadcast.
 
-Network failures fetching /swarm/info are logged and swallowed: the message
-must remain accepted, and the lazy-fetch fallback in the signature verifier
-will populate public_keys on first inbound message from the new member.
+#197 fallback path: when the broadcast omits ``public_key`` (legacy master,
+pre-#214 build), lazy-fetch ``/swarm/info`` on the new member's endpoint to
+retrieve the key. This path is brittle — a single transient HTTPS failure
+permanently desynchronizes the receiver — and is the failure mode #214 was
+filed against. Kept here only for backward compatibility with old masters.
+
+Symmetric DELETE for member_left/member_kicked on ``swarm_members`` only —
+the ``public_keys`` cache survives churn so signature verification of any
+in-flight messages from the removed agent still works.
+
+Failures (broadcast omitted public_key AND /swarm/info fetch failed) are
+logged and swallowed: the message must remain accepted regardless of the
+dispatch outcome. Operator can manually unblock via the SQL-INSERT pattern
+documented on issue #214.
 """
 from __future__ import annotations
 
@@ -251,21 +262,41 @@ async def dispatch_system_message(
                 # proxy for "when the receiver became aware of the join".
                 joined_at_iso = body.timestamp
 
-            public_key = await _fetch_public_key(
-                new_endpoint, target_agent_id, local_agent_id,
-            )
-            if public_key is None:
-                # Fail loud (logged), continue silently. The lazy-fetch
-                # in the signature verifier will populate public_keys on
-                # the first inbound message from the new member, and a
-                # subsequent member_joined retry — or a manual swarm
-                # refresh — can complete the swarm_members write later.
-                logger.warning(
-                    "Skipping swarm_members insert for '%s': public_key "
-                    "fetch failed; lazy-fetch will retry on first verify",
+            # #214: prefer the public_key carried inline in the broadcast
+            # payload over fetching /swarm/info. The master always knows
+            # the new member's key (it just stored the row), so when the
+            # broadcast carries it, no network call is needed and the
+            # fetch race that originally caused #214 disappears.
+            #
+            # Backward compatibility: if the payload omits public_key
+            # (legacy master, pre-#214 build), fall back to the existing
+            # /swarm/info fetch path. The fetch is still brittle in that
+            # window, but no worse than before this PR.
+            inline_public_key = payload.get("public_key")
+            if isinstance(inline_public_key, str) and inline_public_key:
+                public_key: Optional[str] = inline_public_key
+                logger.info(
+                    "Using inline public_key from broadcast payload for "
+                    "'%s' (no /swarm/info fetch needed)",
                     target_agent_id,
                 )
-                return
+            else:
+                public_key = await _fetch_public_key(
+                    new_endpoint, target_agent_id, local_agent_id,
+                )
+                if public_key is None:
+                    # Fail loud (logged), continue silently. Without the
+                    # inline key (legacy broadcast) and a working fetch,
+                    # the receiver cannot satisfy swarm_members.public_key
+                    # NOT NULL. Operator can manually unblock via
+                    # SQL-INSERT (see #214 troubleshooting comment).
+                    logger.warning(
+                        "Skipping swarm_members insert for '%s': "
+                        "broadcast omitted public_key AND /swarm/info "
+                        "fetch failed. See #214 for SQL-unblock pattern.",
+                        target_agent_id,
+                    )
+                    return
 
             await _handle_member_joined(
                 db=db,

--- a/tests/test_event_notifications.py
+++ b/tests/test_event_notifications.py
@@ -165,6 +165,42 @@ class TestBuildNotificationMessage:
         msg = build_notification_message(event)
         assert msg.status == InboxStatus.UNREAD
 
+    def test_member_joined_emits_public_key_when_set(self) -> None:
+        """#214: public_key travels in the broadcast payload when supplied."""
+        event = LifecycleEvent(
+            action=LifecycleAction.MEMBER_JOINED,
+            swarm_id=SWARM_ID,
+            agent_id="new-agent",
+            endpoint="https://new-agent.example.com/swarm",
+            joined_at="2026-05-09T09:11:59.885Z",
+            public_key="Jfz1FlEc2sjJIRn4C6av8I0ki3cgefG2SDisgbfZ9AY=",
+        )
+        msg = build_notification_message(event)
+        content = json.loads(msg.content)
+        assert content["action"] == "member_joined"
+        assert content["public_key"] == (
+            "Jfz1FlEc2sjJIRn4C6av8I0ki3cgefG2SDisgbfZ9AY="
+        )
+        assert content["endpoint"] == "https://new-agent.example.com/swarm"
+        assert content["joined_at"] == "2026-05-09T09:11:59.885Z"
+
+    def test_member_joined_omits_public_key_when_unset(self) -> None:
+        """Backward compat: missing public_key MUST be omitted, not null-emitted.
+
+        Receivers running a post-#214 build use ``payload.get("public_key")``
+        and treat None or missing as "fall back to /swarm/info fetch". An
+        explicit null in the payload would short-circuit that branch and
+        cause the receiver to insert with an invalid key.
+        """
+        event = LifecycleEvent(
+            action=LifecycleAction.MEMBER_JOINED,
+            swarm_id=SWARM_ID,
+            agent_id="legacy-agent",
+        )
+        msg = build_notification_message(event)
+        content = json.loads(msg.content)
+        assert "public_key" not in content
+
 
 class TestPersistNotification:
     """Tests for persisting notifications to the database."""

--- a/tests/test_master_broadcast.py
+++ b/tests/test_master_broadcast.py
@@ -199,6 +199,43 @@ class TestBuildBroadcastEnvelope:
         assert content["joined_at"] == "2026-04-27T06:21:32.000Z"
         assert content["swarm_id"] == SWARM_ID
 
+    def test_payload_includes_public_key_when_supplied(self) -> None:
+        """#214: receiver can populate swarm_members directly when key is inline."""
+        private_key = Ed25519PrivateKey.generate()
+        envelope = build_broadcast_envelope(
+            swarm_id=SWARM_ID,
+            master_id=MASTER_ID,
+            master_endpoint=MASTER_ENDPOINT,
+            master_private_key=private_key,
+            new_agent_id=NEW_AGENT_ID,
+            new_agent_endpoint=NEW_AGENT_ENDPOINT,
+            joined_at=datetime(2026, 5, 9, 9, 11, 59, tzinfo=timezone.utc),
+            new_agent_public_key=NEW_AGENT_PUBKEY_B64,
+        )
+        content = json.loads(envelope["content"])
+        assert content["public_key"] == NEW_AGENT_PUBKEY_B64
+
+    def test_payload_omits_public_key_when_not_supplied(self) -> None:
+        """#214: legacy callers (no public_key) produce backward-compat payload.
+
+        Receivers must see the field MISSING, not null — they branch on
+        ``isinstance(payload.get("public_key"), str) and payload["public_key"]``.
+        A null-emitted field would skip the fetch fallback and break dispatch.
+        """
+        private_key = Ed25519PrivateKey.generate()
+        envelope = build_broadcast_envelope(
+            swarm_id=SWARM_ID,
+            master_id=MASTER_ID,
+            master_endpoint=MASTER_ENDPOINT,
+            master_private_key=private_key,
+            new_agent_id=NEW_AGENT_ID,
+            new_agent_endpoint=NEW_AGENT_ENDPOINT,
+            joined_at=datetime(2026, 5, 9, 9, 11, 59, tzinfo=timezone.utc),
+            # new_agent_public_key intentionally omitted
+        )
+        content = json.loads(envelope["content"])
+        assert "public_key" not in content
+
     def test_envelope_has_signature(self) -> None:
         """Signature field is non-empty base64 — receiver MAY verify."""
         private_key = Ed25519PrivateKey.generate()

--- a/tests/test_receiver_member_sync.py
+++ b/tests/test_receiver_member_sync.py
@@ -236,6 +236,144 @@ class TestMemberJoinedReceiverDispatch:
         assert keys[0]["endpoint"] == NEW_AGENT_ENDPOINT
         assert keys[0]["fetched_at"]  # any non-empty ISO timestamp
 
+    def test_inline_public_key_skips_fetch_and_inserts(
+        self, tmp_path: Path,
+    ) -> None:
+        """#214: when broadcast carries public_key inline, no /swarm/info fetch.
+
+        The master always knows the new member's public_key (it just
+        stored the row via add_member). Carrying the key in the
+        broadcast eliminates the receiver-side fetch, which is the
+        brittle path that caused #214 — a single transient HTTPS failure
+        permanently desynchronizes the receiver. With the inline key,
+        even an unreachable /swarm/info endpoint cannot break dispatch.
+        """
+        db_path = tmp_path / "inline.db"
+        _seed_swarm(db_path)
+        config = _make_config(db_path)
+
+        with patch(
+            "src.server.system_dispatch.httpx.AsyncClient",
+        ) as mock_client_factory:
+            # If the dispatcher tries to use httpx at all, the test
+            # fails — the inline path must NOT call the network.
+            mock_instance = AsyncMock()
+            mock_instance.__aenter__.return_value = mock_instance
+            mock_instance.__aexit__.return_value = None
+            mock_instance.get = AsyncMock(
+                side_effect=AssertionError(
+                    "/swarm/info must NOT be fetched when "
+                    "public_key is inline (#214)",
+                ),
+            )
+            mock_client_factory.return_value = mock_instance
+
+            with TestClient(create_app(config)) as client:
+                msg = _system_message(
+                    action="member_joined",
+                    target_agent_id=NEW_AGENT_ID,
+                    sender_endpoint=NEW_AGENT_ENDPOINT,
+                    extra_content={
+                        "endpoint": NEW_AGENT_ENDPOINT,
+                        "joined_at": "2026-05-09T09:11:59.885Z",
+                        "public_key": NEW_AGENT_PUBKEY,
+                    },
+                )
+                response = client.post(
+                    "/swarm/message",
+                    json=msg,
+                    headers={
+                        "Content-Type": "application/json",
+                        "X-Agent-ID": MASTER_AGENT_ID,
+                        "X-Swarm-Protocol": "0.1.0",
+                    },
+                )
+                assert response.status_code == 200
+                assert response.json()["status"] == "queued"
+
+            # The /swarm/info endpoint MUST NOT have been called.
+            mock_instance.get.assert_not_called()
+
+        # 5 NOT NULL columns populated from the inline payload alone.
+        members = _read_table(
+            db_path, "swarm_members",
+            where=f"agent_id = '{NEW_AGENT_ID}' AND swarm_id = '{SWARM_ID}'",
+        )
+        assert len(members) == 1
+        row = members[0]
+        assert row["agent_id"] == NEW_AGENT_ID
+        assert row["swarm_id"] == SWARM_ID
+        assert row["endpoint"] == NEW_AGENT_ENDPOINT
+        assert row["public_key"] == NEW_AGENT_PUBKEY
+        assert row["joined_at"] == "2026-05-09T09:11:59.885Z"
+
+        # public_keys cache pre-warmed.
+        keys = _read_table(
+            db_path, "public_keys", where=f"agent_id = '{NEW_AGENT_ID}'",
+        )
+        assert len(keys) == 1
+        assert keys[0]["public_key"] == NEW_AGENT_PUBKEY
+        assert keys[0]["endpoint"] == NEW_AGENT_ENDPOINT
+
+    def test_inline_public_key_survives_unreachable_swarm_info(
+        self, tmp_path: Path,
+    ) -> None:
+        """#214 regression: original failure mode no longer applies when key is inline.
+
+        Reproduces the live-incident shape: receiver gets the broadcast
+        moments after the new agent's CF A-record landed, /swarm/info on
+        the new agent is unreachable. With the legacy payload (#197 path)
+        the insert was skipped — see test_swarm_info_unreachable_does_not_crash.
+        With the inline public_key (#214 path), the insert succeeds even
+        though the network would have failed.
+        """
+        import httpx
+
+        db_path = tmp_path / "inline_recovers.db"
+        _seed_swarm(db_path)
+        config = _make_config(db_path)
+
+        with patch(
+            "src.server.system_dispatch.httpx.AsyncClient",
+        ) as mock_client_factory:
+            mock_instance = AsyncMock()
+            mock_instance.__aenter__.return_value = mock_instance
+            mock_instance.__aexit__.return_value = None
+            # If for any reason the dispatcher DOES try to fetch, it fails.
+            mock_instance.get = AsyncMock(
+                side_effect=httpx.ConnectError("connection refused"),
+            )
+            mock_client_factory.return_value = mock_instance
+            with TestClient(create_app(config)) as client:
+                msg = _system_message(
+                    action="member_joined",
+                    target_agent_id=NEW_AGENT_ID,
+                    sender_endpoint=NEW_AGENT_ENDPOINT,
+                    extra_content={
+                        "endpoint": NEW_AGENT_ENDPOINT,
+                        "joined_at": "2026-05-09T09:11:59.885Z",
+                        "public_key": NEW_AGENT_PUBKEY,
+                    },
+                )
+                response = client.post(
+                    "/swarm/message",
+                    json=msg,
+                    headers={
+                        "Content-Type": "application/json",
+                        "X-Agent-ID": MASTER_AGENT_ID,
+                        "X-Swarm-Protocol": "0.1.0",
+                    },
+                )
+                assert response.status_code == 200
+
+        # The row MUST be present despite /swarm/info being unreachable.
+        members = _read_table(
+            db_path, "swarm_members",
+            where=f"agent_id = '{NEW_AGENT_ID}'",
+        )
+        assert len(members) == 1
+        assert members[0]["public_key"] == NEW_AGENT_PUBKEY
+
     def test_swarm_info_unreachable_does_not_crash(
         self, tmp_path: Path,
     ) -> None:


### PR DESCRIPTION
## Summary

Fix #214: receiver-side `member_joined` dispatch never gets stuck on a transient `/swarm/info` fetch failure again, because the broadcast now carries the new member's `public_key` inline.

The master always knows the new member's key (it just stored the row via `add_member`). Carrying it through the broadcast eliminates the receiver-side fetch entirely, which is the brittle path that caused #214 — a single transient HTTPS failure permanently desynchronizes the receiver, and the "lazy-fetch in signature verifier will retry" promise in the comment is unbacked (no such middleware exists).

## What changed

- `LifecycleEvent` gains optional `public_key` field
- `build_notification_message` emits `public_key` when set; **omits** when unset (never null-emits — receivers branch on `isinstance(payload.get("public_key"), str)`)
- `notify_member_joined` accepts and threads `public_key`
- `build_broadcast_envelope` accepts `new_agent_public_key`, includes in signed content payload
- `broadcast_member_joined` accepts and passes through `new_agent_public_key`
- `routes/join.py` passes `body.sender.public_key` to both notification + broadcast
- `system_dispatch.dispatch_system_message` prefers inline `public_key`, falls back to `/swarm/info` fetch when missing (backward compatibility for legacy masters running pre-#214 builds)

7 files changed, 318 insertions, 43 deletions.

## Test plan

- [x] `LifecycleEvent` emits `public_key` when set; omits (not null) when unset
- [x] Envelope payload includes `public_key` when supplied; omits when not
- [x] Receiver dispatch with inline key skips fetch (asserts `httpx.get` is **never** called) and inserts the row directly
- [x] Receiver dispatch with inline key **survives** an unreachable `/swarm/info` (regression test for the original #214 incident shape)
- [x] Existing `test_swarm_info_unreachable_does_not_crash` still passes (legacy payload path unchanged: fetch fails → no insert, message queued)
- [x] `pytest tests/test_event_notifications.py tests/test_master_broadcast.py tests/test_receiver_member_sync.py` — **42 passed**
- [x] Full suite: **555 passed**, 2 failures in `tests/cli/test_messages.py` are pre-existing (verified on `main`), unrelated to this PR
- [x] `ruff check` on changed files: clean (2 pre-existing F401s in `test_event_notifications.py` are not from this PR; verified on `main`)
- [x] `bash -n` / AST parse: all 7 files clean

## Live evidence (issue #214)

The bug was diagnosed against ivory-ideoon's broadcast at 09:11:59Z 2026-05-09. The `_fetch_public_key` fetch raced with the freshly-landed CF A-record and timed out at 09:12:05Z on multiple peers. Each peer's `swarm_members` permanently lacked ivory until manual SQL-INSERT.

Smoking-gun journal entries from the live incident:
```
WARNING Failed to fetch /swarm/info for new member 'ivory-ideoon'
        at https://ivory-ideoon.marbell.com/swarm:
WARNING Skipping swarm_members insert for 'ivory-ideoon': public_key
        fetch failed; lazy-fetch will retry on first verify
```

Both lines disappear with this fix — the receiver never tries the fetch when the master sends a #214-aware build. With this PR, the same incident produces a single insert from the broadcast payload alone, regardless of whether the new agent's public endpoint is reachable at the receive moment.

Cross-references:
- Issue #214 — bug report + 3-option fix shape
- [Smoking-gun analysis](https://github.com/finml-sage/agent-swarm-protocol/issues/214#issuecomment-4412207430)
- [Operational unblock pattern](https://github.com/finml-sage/agent-swarm-protocol/issues/214#issuecomment-4412227696) (for nodes still stuck on legacy masters before this lands)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
