### PR TITLE
fix(server): authenticate private management API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,6 +32,11 @@ AGENT_ENDPOINT=https://agent.example.com/swarm
 # [required] Base64-encoded Ed25519 public key for signature verification
 AGENT_PUBLIC_KEY=your-base64-encoded-public-key
 
+# Private inbox/outbox management API. Disabled unless explicitly enabled.
+# Store the same token in ~/.swarm/management.token (mode 0600) for the CLI.
+MANAGEMENT_API_ENABLED=false
+#MANAGEMENT_API_TOKEN=replace-with-a-long-random-token
+
 # [optional] Path to your agent's Ed25519 private key (32 raw bytes), used
 # by the master to sign cross-host member_joined broadcasts (#200). When
 # unset, joins still succeed and the local master-side notification still

--- a/docs/CLAUDE-INTEGRATION.md
+++ b/docs/CLAUDE-INTEGRATION.md
@@ -407,7 +407,10 @@ swarm sent --limit 10
 ### Important Notes
 
 - **Do NOT query `message_queue` directly.** The `message_queue` table is a legacy internal table. All agent-facing messages are stored in the `inbox` table and should be accessed via the CLI or the `/api/inbox` REST API.
-- The CLI talks to the FastAPI server's `/api/inbox` endpoints. Ensure your reverse proxy (Angie/nginx) forwards `/api/inbox` and `/api/outbox` to the backend.
+- The CLI talks to the authenticated FastAPI `/api/inbox` endpoints. Enable
+  the management API only with `MANAGEMENT_API_TOKEN`, store the matching token
+  in `~/.swarm/management.token` with mode `0600`, and ensure the reverse proxy
+  never strips the `Authorization` header.
 - Messages have a lifecycle: `unread` → `read` → `archived` → `deleted`. The CLI auto-marks messages as `read` when displayed (use `--no-mark-read` to prevent this).
 
 ## Testing

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -28,6 +28,18 @@ Applied per-IP by the rate limiting middleware.
 |----------|----------|---------|-------------|
 | `DB_PATH` | No | `data/swarm.db` | Path to SQLite database for message persistence and swarm state |
 
+## Management API
+
+Inbox and outbox REST routes are private management surfaces and are disabled
+by default. When enabled, every `/api/inbox` and `/api/outbox` request requires
+`Authorization: Bearer <token>`. The CLI reads the same token from
+`~/.swarm/management.token`; keep that file owner-only (`0600`).
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `MANAGEMENT_API_ENABLED` | No | `false` | Mount the authenticated inbox/outbox REST routes. |
+| `MANAGEMENT_API_TOKEN` | When enabled | - | Long random Bearer token for the private management API. |
+
 ## Wake Trigger
 
 Controls the server-side wake trigger that evaluates incoming messages and
@@ -73,7 +85,8 @@ The server enforces these validation rules at startup:
 
 1. `AGENT_ID`, `AGENT_ENDPOINT`, and `AGENT_PUBLIC_KEY` are **always required**.
    The server will refuse to start without them.
-2. If `WAKE_EP_INVOKE_METHOD` is `tmux`, `WAKE_EP_TMUX_TARGET` is required.
+2. If `MANAGEMENT_API_ENABLED=true`, `MANAGEMENT_API_TOKEN` is required.
+3. If `WAKE_EP_INVOKE_METHOD` is `tmux`, `WAKE_EP_TMUX_TARGET` is required.
 
 ## Quick Start
 

--- a/docs/HOST-DEPLOYMENT.md
+++ b/docs/HOST-DEPLOYMENT.md
@@ -119,6 +119,10 @@ AGENT_PUBLIC_KEY=your-base64-encoded-public-key
 # Shared database path (same file the CLI and hooks use)
 DB_PATH=/home/agent/.swarm/swarm.db
 
+# Private inbox/outbox API (generate a distinct long random value)
+MANAGEMENT_API_ENABLED=true
+MANAGEMENT_API_TOKEN=replace-with-a-long-random-token
+
 # Optional: Agent metadata
 AGENT_NAME=My Agent
 AGENT_DESCRIPTION=A swarm protocol agent
@@ -140,6 +144,11 @@ EOF
 
 # Restrict permissions (contains keys and secrets)
 sudo chmod 600 /etc/agent-swarm-protocol.env
+
+# Give the local CLI the same token without placing it in config.yaml.
+printf '%s\n' 'replace-with-the-same-long-random-token' \
+  | install -m 600 /dev/stdin /home/agent/.swarm/management.token
+sudo chown agent:agent /home/agent/.swarm/management.token
 ```
 
 To get your public key in base64 format from an existing agent key:

--- a/src/cli/commands/messages.py
+++ b/src/cli/commands/messages.py
@@ -19,7 +19,7 @@ from src.cli.output import (
     json_output,
     render_batch,
 )
-from src.cli.utils import ConfigManager, resolve_swarm_id, SwarmIdError
+from src.cli.utils import ConfigManager, SwarmIdError, resolve_swarm_id
 from src.cli.utils.config import ConfigError
 
 console = Console()
@@ -27,6 +27,12 @@ console = Console()
 _VALID_STATUSES = ("unread", "read", "archived", "all")
 
 _HTTP_TIMEOUT = 15.0
+
+
+def _management_headers() -> dict[str, str]:
+    """Build the private API Authorization header from local config."""
+    token = ConfigManager().load_management_token()
+    return {"Authorization": f"Bearer {token}"}
 
 
 def _server_base_url(endpoint: str) -> str:
@@ -43,7 +49,10 @@ def _server_base_url(endpoint: str) -> str:
 
 
 async def _fetch_inbox(
-    base_url: str, swarm_id: str, limit: int, status_filter: str,
+    base_url: str,
+    swarm_id: str,
+    limit: int,
+    status_filter: str,
 ) -> dict:
     """GET /api/inbox from the server."""
     params: dict[str, str | int] = {
@@ -51,7 +60,9 @@ async def _fetch_inbox(
         "status": status_filter,
         "limit": limit,
     }
-    async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT) as client:
+    async with httpx.AsyncClient(
+        timeout=_HTTP_TIMEOUT, headers=_management_headers()
+    ) as client:
         resp = await client.get(f"{base_url}/api/inbox", params=params)
         resp.raise_for_status()
         return resp.json()
@@ -60,7 +71,9 @@ async def _fetch_inbox(
 async def _fetch_count(base_url: str, swarm_id: str) -> dict:
     """GET /api/inbox/count from the server."""
     params = {"swarm_id": swarm_id}
-    async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT) as client:
+    async with httpx.AsyncClient(
+        timeout=_HTTP_TIMEOUT, headers=_management_headers()
+    ) as client:
         resp = await client.get(f"{base_url}/api/inbox/count", params=params)
         resp.raise_for_status()
         return resp.json()
@@ -69,17 +82,23 @@ async def _fetch_count(base_url: str, swarm_id: str) -> dict:
 async def _batch_mark_read(base_url: str, message_ids: list[str]) -> dict:
     """POST /api/inbox/batch to mark messages as read."""
     body = {"message_ids": message_ids, "action": "read"}
-    async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT) as client:
+    async with httpx.AsyncClient(
+        timeout=_HTTP_TIMEOUT, headers=_management_headers()
+    ) as client:
         resp = await client.post(f"{base_url}/api/inbox/batch", json=body)
         resp.raise_for_status()
         return resp.json()
 
 
 async def _batch_inbox_action(
-    base_url: str, message_ids: list[str], action: str,
+    base_url: str,
+    message_ids: list[str],
+    action: str,
 ) -> dict:
     """POST /api/inbox/batch on the server."""
-    async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT) as client:
+    async with httpx.AsyncClient(
+        timeout=_HTTP_TIMEOUT, headers=_management_headers()
+    ) as client:
         resp = await client.post(
             f"{base_url}/api/inbox/batch",
             json={"message_ids": message_ids, "action": action},
@@ -88,10 +107,11 @@ async def _batch_inbox_action(
         return resp.json()
 
 
-
 async def _archive_message(base_url: str, message_id: str) -> dict:
     """POST /api/inbox/{id}/archive."""
-    async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT) as client:
+    async with httpx.AsyncClient(
+        timeout=_HTTP_TIMEOUT, headers=_management_headers()
+    ) as client:
         resp = await client.post(f"{base_url}/api/inbox/{message_id}/archive")
         if resp.status_code in (200, 400, 404):
             return resp.json()
@@ -101,7 +121,9 @@ async def _archive_message(base_url: str, message_id: str) -> dict:
 
 async def _delete_message(base_url: str, message_id: str) -> dict:
     """POST /api/inbox/{id}/delete."""
-    async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT) as client:
+    async with httpx.AsyncClient(
+        timeout=_HTTP_TIMEOUT, headers=_management_headers()
+    ) as client:
         resp = await client.post(f"{base_url}/api/inbox/{message_id}/delete")
         if resp.status_code in (200, 404):
             return resp.json()
@@ -175,9 +197,9 @@ def _handle_delete(delete_id: str, json_flag: bool) -> None:
         format_success(console, f"Message {delete_id[:12]}... deleted")
 
 
-
 def _handle_archive_all(
-    swarm_id: str | None, json_flag: bool,
+    swarm_id: str | None,
+    json_flag: bool,
 ) -> None:
     """Archive all read messages in a swarm."""
     try:
@@ -218,9 +240,14 @@ def _handle_archive_all(
 
 
 def messages_command(
-    swarm_id: str | None, limit: int, status_filter: str,
-    archive: str | None, delete: str | None,
-    no_mark_read: bool, count: bool, json_flag: bool,
+    swarm_id: str | None,
+    limit: int,
+    status_filter: str,
+    archive: str | None,
+    delete: str | None,
+    no_mark_read: bool,
+    count: bool,
+    json_flag: bool,
     archive_all: bool = False,
 ) -> None:
     """List and manage messages via the server inbox API."""
@@ -254,7 +281,8 @@ def messages_command(
     # Validate status filter
     if status_filter not in _VALID_STATUSES:
         format_error(
-            console, f"Invalid status '{status_filter}'",
+            console,
+            f"Invalid status '{status_filter}'",
             hint=f"Valid values: {', '.join(_VALID_STATUSES)}",
         )
         raise typer.Exit(code=2)
@@ -283,13 +311,17 @@ def messages_command(
         if json_flag:
             json_output(console, {"swarm_id": sid, **data})
         else:
-            console.print(f"[cyan]Unread:[/cyan] {data['unread']}  "
-                          f"[dim]Read:[/dim] {data['read']}  "
-                          f"[dim]Total:[/dim] {data['total']}")
+            console.print(
+                f"[cyan]Unread:[/cyan] {data['unread']}  "
+                f"[dim]Read:[/dim] {data['read']}  "
+                f"[dim]Total:[/dim] {data['total']}"
+            )
         return
 
     # List mode
-    data = _run_async(_fetch_inbox(base_url, sid, limit, status_filter), "list messages")
+    data = _run_async(
+        _fetch_inbox(base_url, sid, limit, status_filter), "list messages"
+    )
     msgs = data.get("messages", [])
 
     # Auto-mark-read: after listing unread messages, mark them as read

--- a/src/cli/utils/config.py
+++ b/src/cli/utils/config.py
@@ -35,12 +35,14 @@ class ConfigManager:
     CONFIG_FILE = "config.yaml"
     KEY_FILE = "agent.key"
     DB_FILE = "swarm.db"
+    MANAGEMENT_TOKEN_FILE = "management.token"
 
     def __init__(self, config_dir: Path | None = None) -> None:
         self._config_dir = config_dir or self.DEFAULT_DIR
         self._config_path = self._config_dir / self.CONFIG_FILE
         self._key_path = self._config_dir / self.KEY_FILE
         self._db_path = self._config_dir / self.DB_FILE
+        self._management_token_path = self._config_dir / self.MANAGEMENT_TOKEN_FILE
 
     @property
     def config_dir(self) -> Path:
@@ -53,6 +55,10 @@ class ConfigManager:
     @property
     def db_path(self) -> Path:
         return self._db_path
+
+    @property
+    def management_token_path(self) -> Path:
+        return self._management_token_path
 
     def exists(self) -> bool:
         """Check if configuration exists."""
@@ -94,12 +100,14 @@ class ConfigManager:
         self, agent_id: str, endpoint: str, private_key: Ed25519PrivateKey
     ) -> None:
         """Save configuration to file."""
-        self._config_dir.mkdir(parents=True, exist_ok=True)
+        self._config_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
+        self._config_dir.chmod(0o700)
 
         config_data = {"agent_id": agent_id, "endpoint": endpoint}
 
         with open(self._config_path, "w") as f:
             yaml.safe_dump(config_data, f, default_flow_style=False)
+        self._config_path.chmod(0o600)
 
         key_bytes = private_key.private_bytes(
             Encoding.Raw, PrivateFormat.Raw, NoEncryption()
@@ -108,3 +116,16 @@ class ConfigManager:
             f.write(key_bytes)
 
         self._key_path.chmod(0o600)
+
+    def load_management_token(self) -> str:
+        """Load the private management API token from its owner-only file."""
+        if not self._management_token_path.exists():
+            raise ConfigError(
+                f"Management API token not configured at {self._management_token_path}"
+            )
+        token = self._management_token_path.read_text().strip()
+        if not token:
+            raise ConfigError(
+                f"Management API token is empty at {self._management_token_path}"
+            )
+        return token

--- a/src/server/app.py
+++ b/src/server/app.py
@@ -1,4 +1,5 @@
 """FastAPI application factory."""
+
 import logging
 from contextlib import asynccontextmanager
 from pathlib import Path
@@ -17,24 +18,25 @@ verify_package_integrity()
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
 from pydantic import ValidationError
+
+from src.claude.notification_preferences import NotificationPreferences
+from src.claude.session_manager import SessionManager
+from src.claude.wake_trigger import WakeTrigger
 from src.server.config import ServerConfig, load_config_from_env
 from src.server.invoke_tmux import TmuxInvokeConfig
 from src.server.invoke_zellij import ZellijInvokeConfig
 from src.server.invoker import AgentInvoker
-from src.server.middleware.rate_limit import RateLimitMiddleware
 from src.server.middleware.logging import RequestLoggingMiddleware
-from src.server.models.responses import ErrorResponse, ErrorDetail
-from src.server.routes.message import create_message_router
-from src.server.routes.join import create_join_router
+from src.server.middleware.rate_limit import RateLimitMiddleware
+from src.server.models.responses import ErrorDetail, ErrorResponse
 from src.server.routes.health import create_health_router
-from src.server.routes.info import create_info_router
-from src.server.routes.wake import create_wake_router
 from src.server.routes.inbox import create_inbox_router
+from src.server.routes.info import create_info_router
+from src.server.routes.join import create_join_router
+from src.server.routes.message import create_message_router
 from src.server.routes.outbox import create_outbox_router
+from src.server.routes.wake import create_wake_router
 from src.state.database import DatabaseManager
-from src.claude.notification_preferences import NotificationPreferences
-from src.claude.session_manager import SessionManager
-from src.claude.wake_trigger import WakeTrigger
 
 logger = logging.getLogger(__name__)
 
@@ -93,7 +95,8 @@ def create_app(config: Optional[ServerConfig] = None) -> FastAPI:
         wake_trigger = _build_wake_trigger(config, db_manager)
         if wake_trigger is not None:
             logger.info(
-                "WakeTrigger active, endpoint=%s", config.wake.endpoint,
+                "WakeTrigger active, endpoint=%s",
+                config.wake.endpoint,
             )
         else:
             logger.info("WakeTrigger disabled")
@@ -109,14 +112,22 @@ def create_app(config: Optional[ServerConfig] = None) -> FastAPI:
         lifespan=lifespan,
     )
     app.add_middleware(RequestLoggingMiddleware)
-    app.add_middleware(RateLimitMiddleware, requests_per_minute=config.rate_limit.messages_per_minute)
+    app.add_middleware(
+        RateLimitMiddleware, requests_per_minute=config.rate_limit.messages_per_minute
+    )
     app.add_exception_handler(ValidationError, _validation_error_handler)
     app.include_router(create_message_router(db_manager, config.agent.agent_id))
     app.include_router(create_join_router(config, db_manager))
     app.include_router(create_health_router(config))
     app.include_router(create_info_router(config))
-    app.include_router(create_inbox_router(db_manager))
-    app.include_router(create_outbox_router(db_manager))
+    if config.management_api.enabled:
+        app.include_router(create_inbox_router(db_manager, config.management_api.token))
+        app.include_router(
+            create_outbox_router(db_manager, config.management_api.token)
+        )
+        logger.info("Authenticated management API active")
+    else:
+        logger.info("Management API disabled")
 
     # Wire /api/wake endpoint when enabled
     if config.wake_endpoint.enabled:
@@ -135,7 +146,8 @@ def create_app(config: Optional[ServerConfig] = None) -> FastAPI:
             )
         )
         logger.info(
-            "Wake endpoint active, method=%s", config.wake_endpoint.invoke_method,
+            "Wake endpoint active, method=%s",
+            config.wake_endpoint.invoke_method,
         )
     else:
         logger.info("Wake endpoint disabled")
@@ -143,6 +155,14 @@ def create_app(config: Optional[ServerConfig] = None) -> FastAPI:
     return app
 
 
-async def _validation_error_handler(request: Request, exc: ValidationError) -> JSONResponse:
-    response = ErrorResponse(error=ErrorDetail(code="INVALID_FORMAT", message="Request validation failed", details={"validation_errors": exc.errors()}))
+async def _validation_error_handler(
+    request: Request, exc: ValidationError
+) -> JSONResponse:
+    response = ErrorResponse(
+        error=ErrorDetail(
+            code="INVALID_FORMAT",
+            message="Request validation failed",
+            details={"validation_errors": exc.errors()},
+        )
+    )
     return JSONResponse(status_code=400, content=response.model_dump())

--- a/src/server/config.py
+++ b/src/server/config.py
@@ -1,15 +1,14 @@
 """Server configuration."""
+
 import logging
+import os
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Optional
-import os
 
 logger = logging.getLogger(__name__)
 
-_RECOGNISED_BOOL_VALUES = frozenset(
-    ("1", "true", "yes", "0", "false", "no")
-)
+_RECOGNISED_BOOL_VALUES = frozenset(("1", "true", "yes", "0", "false", "no"))
 
 
 @dataclass(frozen=True)
@@ -31,6 +30,14 @@ class AgentConfig:
 @dataclass(frozen=True)
 class RateLimitConfig:
     messages_per_minute: int = 60
+
+
+@dataclass(frozen=True)
+class ManagementApiConfig:
+    """Private inbox/outbox management API configuration."""
+
+    enabled: bool = False
+    token: str = ""
 
 
 @dataclass(frozen=True)
@@ -76,6 +83,7 @@ class WakeEndpointConfig:
 class ServerConfig:
     agent: AgentConfig
     rate_limit: RateLimitConfig = field(default_factory=RateLimitConfig)
+    management_api: ManagementApiConfig = field(default_factory=ManagementApiConfig)
     db_path: Path = field(default_factory=lambda: Path("data/swarm.db"))
     wake: WakeConfig = field(default_factory=WakeConfig)
     wake_endpoint: WakeEndpointConfig = field(default_factory=WakeEndpointConfig)
@@ -117,6 +125,15 @@ def load_config_from_env() -> ServerConfig:
     if missing:
         raise ValueError(f"Missing: {', '.join(missing)}")
 
+    management_api_enabled = _parse_bool(
+        os.environ.get("MANAGEMENT_API_ENABLED", ""), default=False
+    )
+    management_api_token = os.environ.get("MANAGEMENT_API_TOKEN", "")
+    if management_api_enabled and not management_api_token:
+        raise ValueError(
+            "MANAGEMENT_API_TOKEN required when MANAGEMENT_API_ENABLED is set"
+        )
+
     wake_enabled = _parse_bool(os.environ.get("WAKE_ENABLED", ""), default=True)
     wake_endpoint_url = os.environ.get(
         "WAKE_ENDPOINT", "http://localhost:8080/api/wake"
@@ -124,9 +141,7 @@ def load_config_from_env() -> ServerConfig:
     if wake_enabled and not wake_endpoint_url:
         raise ValueError("WAKE_ENDPOINT required when WAKE_ENABLED is set")
 
-    wake_ep_enabled = _parse_bool(
-        os.environ.get("WAKE_EP_ENABLED", ""), default=True
-    )
+    wake_ep_enabled = _parse_bool(os.environ.get("WAKE_EP_ENABLED", ""), default=True)
     wake_ep_secret = os.environ.get("WAKE_EP_SECRET", "")
     if wake_ep_enabled and not wake_ep_secret:
         logger.warning(
@@ -164,7 +179,13 @@ def load_config_from_env() -> ServerConfig:
             private_key_path=private_key_path,
         ),
         rate_limit=RateLimitConfig(
-            messages_per_minute=int(os.environ.get("RATE_LIMIT_MESSAGES_PER_MINUTE", "60")),
+            messages_per_minute=int(
+                os.environ.get("RATE_LIMIT_MESSAGES_PER_MINUTE", "60")
+            ),
+        ),
+        management_api=ManagementApiConfig(
+            enabled=management_api_enabled,
+            token=management_api_token,
         ),
         db_path=Path(os.environ.get("DB_PATH", "data/swarm.db")),
         wake=WakeConfig(

--- a/src/server/management_auth.py
+++ b/src/server/management_auth.py
@@ -1,0 +1,35 @@
+"""Authentication dependency for private management API routes."""
+
+from secrets import compare_digest
+from typing import Annotated, Awaitable, Callable
+
+from fastapi import Header, HTTPException, status
+
+ManagementAuthDependency = Callable[..., Awaitable[None]]
+
+
+def create_management_auth_dependency(
+    expected_token: str,
+) -> ManagementAuthDependency:
+    """Create a fail-closed Bearer-token dependency for management routes."""
+    if not expected_token:
+        raise ValueError("Management API token must not be empty")
+
+    async def require_management_auth(
+        authorization: Annotated[str | None, Header()] = None,
+    ) -> None:
+        scheme, separator, credentials = (authorization or "").partition(" ")
+        is_authorized = (
+            separator == " "
+            and scheme.lower() == "bearer"
+            and bool(credentials)
+            and compare_digest(credentials, expected_token)
+        )
+        if not is_authorized:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Valid management API Bearer token required",
+                headers={"WWW-Authenticate": "Bearer"},
+            )
+
+    return require_management_auth

--- a/src/server/routes/inbox.py
+++ b/src/server/routes/inbox.py
@@ -7,9 +7,10 @@ archived, and soft-delete. Replaces the old /api/messages endpoints.
 import logging
 from typing import Annotated
 
-from fastapi import APIRouter, Path, Query, status
+from fastapi import APIRouter, Depends, Path, Query, status
 from fastapi.responses import JSONResponse
 
+from src.server.management_auth import create_management_auth_dependency
 from src.server.models.inbox import (
     InboxBatchRequest,
     InboxBatchResponse,
@@ -26,16 +27,23 @@ from src.state.repositories.inbox import InboxRepository
 logger = logging.getLogger(__name__)
 
 _VALID_STATUSES = frozenset({"unread", "read", "archived", "all"})
-_ACTION_MAP = {"read": InboxStatus.READ, "archive": InboxStatus.ARCHIVED, "delete": InboxStatus.DELETED}
+_ACTION_MAP = {
+    "read": InboxStatus.READ,
+    "archive": InboxStatus.ARCHIVED,
+    "delete": InboxStatus.DELETED,
+}
 
 
-def create_inbox_router(db: DatabaseManager) -> APIRouter:
-    """Create the inbox router with injected database dependency."""
-    router = APIRouter()
+def create_inbox_router(db: DatabaseManager, management_token: str) -> APIRouter:
+    """Create the authenticated inbox router."""
+    require_management_auth = create_management_auth_dependency(management_token)
+    router = APIRouter(dependencies=[Depends(require_management_auth)])
 
     @router.get("/api/inbox", response_model=InboxListResponse, tags=["inbox"])
     async def list_messages(
-        status_filter: Annotated[str, Query(alias="status", description="unread|read|archived|all")] = "unread",
+        status_filter: Annotated[
+            str, Query(alias="status", description="unread|read|archived|all")
+        ] = "unread",
         swarm_id: Annotated[str | None, Query(description="Swarm ID filter")] = None,
         sender_id: Annotated[str | None, Query(description="Sender ID filter")] = None,
         limit: Annotated[int, Query(ge=1, le=100, description="Max messages")] = 20,
@@ -44,11 +52,15 @@ def create_inbox_router(db: DatabaseManager) -> APIRouter:
         if status_filter not in _VALID_STATUSES:
             return JSONResponse(
                 status_code=status.HTTP_400_BAD_REQUEST,
-                content={"error": f"Invalid status '{status_filter}'. Valid: {', '.join(sorted(_VALID_STATUSES))}"},
+                content={
+                    "error": f"Invalid status '{status_filter}'. Valid: {', '.join(sorted(_VALID_STATUSES))}"
+                },
             )
         async with db.connection() as conn:
             repo = InboxRepository(conn)
-            messages = await repo.list_visible(status_filter, swarm_id, sender_id, limit)
+            messages = await repo.list_visible(
+                status_filter, swarm_id, sender_id, limit
+            )
         items = [msg_to_response(m) for m in messages]
         return InboxListResponse(count=len(items), messages=items)
 
@@ -61,12 +73,16 @@ def create_inbox_router(db: DatabaseManager) -> APIRouter:
             repo = InboxRepository(conn)
             counts = await repo.count_by_status(swarm_id)
         return InboxCountResponse(
-            unread=counts.get("unread", 0), read=counts.get("read", 0),
-            archived=counts.get("archived", 0), deleted=counts.get("deleted", 0),
+            unread=counts.get("unread", 0),
+            read=counts.get("read", 0),
+            archived=counts.get("archived", 0),
+            deleted=counts.get("deleted", 0),
             total=counts.get("total", 0),
         )
 
-    @router.get("/api/inbox/{message_id}", response_model=InboxMessageResponse, tags=["inbox"])
+    @router.get(
+        "/api/inbox/{message_id}", response_model=InboxMessageResponse, tags=["inbox"]
+    )
     async def get_message(
         message_id: Annotated[str, Path(description="Message ID")],
     ) -> InboxMessageResponse | JSONResponse:
@@ -75,13 +91,20 @@ def create_inbox_router(db: DatabaseManager) -> APIRouter:
             repo = InboxRepository(conn)
             msg = await repo.get_by_id(message_id)
             if msg is None:
-                return JSONResponse(status_code=404, content={"error": f"Message {message_id} not found"})
+                return JSONResponse(
+                    status_code=404,
+                    content={"error": f"Message {message_id} not found"},
+                )
             if msg.status == InboxStatus.UNREAD:
                 await repo.mark_read(message_id)
                 msg = await repo.get_by_id(message_id)
         return msg_to_response(msg)  # type: ignore[arg-type]
 
-    @router.post("/api/inbox/{message_id}/read", response_model=InboxStatusResponse, tags=["inbox"])
+    @router.post(
+        "/api/inbox/{message_id}/read",
+        response_model=InboxStatusResponse,
+        tags=["inbox"],
+    )
     async def mark_read(
         message_id: Annotated[str, Path(description="Message ID")],
     ) -> InboxStatusResponse | JSONResponse:
@@ -90,11 +113,18 @@ def create_inbox_router(db: DatabaseManager) -> APIRouter:
             repo = InboxRepository(conn)
             msg = await repo.get_by_id(message_id)
             if msg is None:
-                return JSONResponse(status_code=404, content={"error": f"Message {message_id} not found"})
+                return JSONResponse(
+                    status_code=404,
+                    content={"error": f"Message {message_id} not found"},
+                )
             await repo.mark_read(message_id)
         return InboxStatusResponse(status="read", message_id=message_id)
 
-    @router.post("/api/inbox/{message_id}/archive", response_model=InboxStatusResponse, tags=["inbox"])
+    @router.post(
+        "/api/inbox/{message_id}/archive",
+        response_model=InboxStatusResponse,
+        tags=["inbox"],
+    )
     async def archive_message(
         message_id: Annotated[str, Path(description="Message ID")],
     ) -> InboxStatusResponse | JSONResponse:
@@ -103,13 +133,23 @@ def create_inbox_router(db: DatabaseManager) -> APIRouter:
             repo = InboxRepository(conn)
             msg = await repo.get_by_id(message_id)
             if msg is None:
-                return JSONResponse(status_code=404, content={"error": f"Message {message_id} not found"})
+                return JSONResponse(
+                    status_code=404,
+                    content={"error": f"Message {message_id} not found"},
+                )
             updated = await repo.mark_archived(message_id)
             if not updated:
-                return JSONResponse(status_code=400, content={"error": f"Cannot archive from '{msg.status.value}'"})
+                return JSONResponse(
+                    status_code=400,
+                    content={"error": f"Cannot archive from '{msg.status.value}'"},
+                )
         return InboxStatusResponse(status="archived", message_id=message_id)
 
-    @router.post("/api/inbox/{message_id}/delete", response_model=InboxStatusResponse, tags=["inbox"])
+    @router.post(
+        "/api/inbox/{message_id}/delete",
+        response_model=InboxStatusResponse,
+        tags=["inbox"],
+    )
     async def delete_message(
         message_id: Annotated[str, Path(description="Message ID")],
     ) -> InboxStatusResponse | JSONResponse:
@@ -118,20 +158,29 @@ def create_inbox_router(db: DatabaseManager) -> APIRouter:
             repo = InboxRepository(conn)
             msg = await repo.get_by_id(message_id)
             if msg is None:
-                return JSONResponse(status_code=404, content={"error": f"Message {message_id} not found"})
+                return JSONResponse(
+                    status_code=404,
+                    content={"error": f"Message {message_id} not found"},
+                )
             await repo.mark_deleted(message_id)
         logger.info("Message %s soft-deleted via inbox API", message_id)
         return InboxStatusResponse(status="deleted", message_id=message_id)
 
     @router.post("/api/inbox/batch", response_model=InboxBatchResponse, tags=["inbox"])
-    async def batch_action(body: InboxBatchRequest) -> InboxBatchResponse | JSONResponse:
+    async def batch_action(
+        body: InboxBatchRequest,
+    ) -> InboxBatchResponse | JSONResponse:
         """Batch status update for multiple messages."""
         target_status = _ACTION_MAP.get(body.action)
         if target_status is None:
-            return JSONResponse(status_code=400, content={"error": f"Invalid action '{body.action}'"})
+            return JSONResponse(
+                status_code=400, content={"error": f"Invalid action '{body.action}'"}
+            )
         async with db.connection() as conn:
             repo = InboxRepository(conn)
             updated = await repo.batch_update_status(body.message_ids, target_status)
-        return InboxBatchResponse(action=body.action, updated=updated, total=len(body.message_ids))
+        return InboxBatchResponse(
+            action=body.action, updated=updated, total=len(body.message_ids)
+        )
 
     return router

--- a/src/server/routes/outbox.py
+++ b/src/server/routes/outbox.py
@@ -3,8 +3,9 @@
 import logging
 from typing import Annotated
 
-from fastapi import APIRouter, Query, status
+from fastapi import APIRouter, Depends, Query, status
 
+from src.server.management_auth import create_management_auth_dependency
 from src.server.models.inbox import (
     OutboxCountResponse,
     OutboxListResponse,
@@ -16,9 +17,10 @@ from src.state.repositories.outbox import OutboxRepository
 logger = logging.getLogger(__name__)
 
 
-def create_outbox_router(db: DatabaseManager) -> APIRouter:
-    """Create the outbox router with injected database dependency."""
-    router = APIRouter()
+def create_outbox_router(db: DatabaseManager, management_token: str) -> APIRouter:
+    """Create the authenticated outbox router."""
+    require_management_auth = create_management_auth_dependency(management_token)
+    router = APIRouter(dependencies=[Depends(require_management_auth)])
 
     @router.get(
         "/api/outbox",

--- a/tests/cli/test_config.py
+++ b/tests/cli/test_config.py
@@ -1,8 +1,9 @@
 """Tests for CLI configuration management."""
 
-import pytest
 from pathlib import Path
 from tempfile import TemporaryDirectory
+
+import pytest
 
 from src.cli.utils.config import AgentConfig, ConfigError, ConfigManager
 from src.client import generate_keypair
@@ -57,6 +58,35 @@ class TestConfigManager:
             key_path = config_dir / "agent.key"
             mode = key_path.stat().st_mode & 0o777
             assert mode == 0o600
+
+    def test_state_directory_and_config_permissions(self):
+        """State directory and config are owner-only after save."""
+        with TemporaryDirectory() as tmpdir:
+            config_dir = Path(tmpdir) / "swarm"
+            manager = ConfigManager(config_dir)
+
+            private_key, _ = generate_keypair()
+            manager.save("test-agent", "https://example.com/swarm", private_key)
+
+            assert config_dir.stat().st_mode & 0o777 == 0o700
+            assert (config_dir / "config.yaml").stat().st_mode & 0o777 == 0o600
+
+    def test_load_management_token(self):
+        """Management token is loaded from its dedicated local file."""
+        with TemporaryDirectory() as tmpdir:
+            manager = ConfigManager(Path(tmpdir) / "swarm")
+            manager.config_dir.mkdir()
+            manager.management_token_path.write_text("test-token\n")
+
+            assert manager.load_management_token() == "test-token"
+
+    def test_load_management_token_fails_closed(self):
+        """Missing management credentials never degrade to anonymous access."""
+        with TemporaryDirectory() as tmpdir:
+            manager = ConfigManager(Path(tmpdir) / "swarm")
+
+            with pytest.raises(ConfigError, match="token not configured"):
+                manager.load_management_token()
 
     def test_load_missing_config_raises(self):
         """Loading missing config raises ConfigError."""

--- a/tests/cli/test_messages.py
+++ b/tests/cli/test_messages.py
@@ -12,8 +12,8 @@ from unittest.mock import AsyncMock, patch
 import toon
 from typer.testing import CliRunner
 
+from src.cli.commands.messages import _management_headers, _server_base_url
 from src.cli.main import app
-from src.cli.commands.messages import _server_base_url
 from src.cli.utils.config import ConfigManager
 
 runner = CliRunner()
@@ -40,12 +40,14 @@ def _init_agent(monkeypatch, config_dir: Path) -> None:
 
 def _sample_message(status: str = "unread") -> dict:
     """Return a sample inbox message dict with TOON content_preview."""
-    toon_content = toon.encode({
-        "sender": {"agent_id": "sender-agent"},
-        "recipient": "test-agent",
-        "type": "chat",
-        "content": "Hello from test",
-    })
+    toon_content = toon.encode(
+        {
+            "sender": {"agent_id": "sender-agent"},
+            "recipient": "test-agent",
+            "type": "chat",
+            "content": "Hello from test",
+        }
+    )
     return {
         "message_id": MSG_ID,
         "swarm_id": SWARM_ID,
@@ -66,16 +68,37 @@ class TestServerBaseUrl:
     """Unit tests for the URL derivation helper."""
 
     def test_strips_swarm_path(self):
-        assert _server_base_url("https://host.example.com/swarm") == "https://host.example.com"
+        assert (
+            _server_base_url("https://host.example.com/swarm")
+            == "https://host.example.com"
+        )
 
     def test_strips_trailing_slash(self):
-        assert _server_base_url("https://host.example.com/swarm/") == "https://host.example.com"
+        assert (
+            _server_base_url("https://host.example.com/swarm/")
+            == "https://host.example.com"
+        )
 
     def test_preserves_port(self):
-        assert _server_base_url("http://localhost:8081/swarm") == "http://localhost:8081"
+        assert (
+            _server_base_url("http://localhost:8081/swarm") == "http://localhost:8081"
+        )
 
     def test_no_path(self):
-        assert _server_base_url("https://host.example.com") == "https://host.example.com"
+        assert (
+            _server_base_url("https://host.example.com") == "https://host.example.com"
+        )
+
+
+def test_management_headers_use_local_token(monkeypatch):
+    """Private API calls carry the locally stored Bearer token."""
+    monkeypatch.setattr(
+        ConfigManager,
+        "load_management_token",
+        lambda self: "test-token",
+    )
+
+    assert _management_headers() == {"Authorization": "Bearer test-token"}
 
 
 # ---------------------------------------------------------------------------
@@ -132,7 +155,9 @@ class TestMessagesValidation:
                 result = runner.invoke(
                     app, ["messages", "-s", SWARM_ID, "--status", old_status]
                 )
-                assert result.exit_code == 2, f"Status '{old_status}' should be rejected"
+                assert result.exit_code == 2, (
+                    f"Status '{old_status}' should be rejected"
+                )
 
 
 # ---------------------------------------------------------------------------
@@ -234,7 +259,9 @@ class TestMessagesList:
     @patch("src.cli.commands.messages._batch_mark_read", new_callable=AsyncMock)
     @patch("src.cli.commands.messages._fetch_inbox", new_callable=AsyncMock)
     @patch("src.cli.commands.messages._load_base_url", return_value=BASE_URL)
-    def test_list_no_mark_read_flag(self, mock_url, mock_fetch, mock_batch, monkeypatch):
+    def test_list_no_mark_read_flag(
+        self, mock_url, mock_fetch, mock_batch, monkeypatch
+    ):
         """--no-mark-read prevents auto-marking."""
         mock_fetch.return_value = {"count": 1, "messages": [_sample_message()]}
 
@@ -242,9 +269,7 @@ class TestMessagesList:
             config_dir = Path(tmpdir) / "swarm"
             _init_agent(monkeypatch, config_dir)
 
-            result = runner.invoke(
-                app, ["messages", "-s", SWARM_ID, "--no-mark-read"]
-            )
+            result = runner.invoke(app, ["messages", "-s", SWARM_ID, "--no-mark-read"])
 
         assert result.exit_code == 0
         mock_batch.assert_not_called()
@@ -252,7 +277,9 @@ class TestMessagesList:
     @patch("src.cli.commands.messages._batch_mark_read", new_callable=AsyncMock)
     @patch("src.cli.commands.messages._fetch_inbox", new_callable=AsyncMock)
     @patch("src.cli.commands.messages._load_base_url", return_value=BASE_URL)
-    def test_list_read_status_no_automark(self, mock_url, mock_fetch, mock_batch, monkeypatch):
+    def test_list_read_status_no_automark(
+        self, mock_url, mock_fetch, mock_batch, monkeypatch
+    ):
         """Listing read messages does not trigger auto-mark."""
         mock_fetch.return_value = {"count": 1, "messages": [_sample_message("read")]}
 
@@ -270,7 +297,9 @@ class TestMessagesList:
     @patch("src.cli.commands.messages._batch_mark_read", new_callable=AsyncMock)
     @patch("src.cli.commands.messages._fetch_inbox", new_callable=AsyncMock)
     @patch("src.cli.commands.messages._load_base_url", return_value=BASE_URL)
-    def test_list_all_status_no_automark(self, mock_url, mock_fetch, mock_batch, monkeypatch):
+    def test_list_all_status_no_automark(
+        self, mock_url, mock_fetch, mock_batch, monkeypatch
+    ):
         """Listing with --status all does not trigger auto-mark."""
         mock_fetch.return_value = {"count": 1, "messages": [_sample_message()]}
 
@@ -278,9 +307,7 @@ class TestMessagesList:
             config_dir = Path(tmpdir) / "swarm"
             _init_agent(monkeypatch, config_dir)
 
-            result = runner.invoke(
-                app, ["messages", "-s", SWARM_ID, "--status", "all"]
-            )
+            result = runner.invoke(app, ["messages", "-s", SWARM_ID, "--status", "all"])
 
         assert result.exit_code == 0
         mock_batch.assert_not_called()
@@ -307,7 +334,9 @@ class TestMessagesList:
     @patch("src.cli.commands.messages._batch_mark_read", new_callable=AsyncMock)
     @patch("src.cli.commands.messages._fetch_inbox", new_callable=AsyncMock)
     @patch("src.cli.commands.messages._load_base_url", return_value=BASE_URL)
-    def test_list_json_flag_ignored(self, mock_url, mock_fetch, mock_batch, monkeypatch):
+    def test_list_json_flag_ignored(
+        self, mock_url, mock_fetch, mock_batch, monkeypatch
+    ):
         """--json flag in list mode still produces TOON output (JSON only for --count)."""
         mock_fetch.return_value = {"count": 1, "messages": [_sample_message()]}
         mock_batch.return_value = {"action": "read", "updated": 1, "total": 1}
@@ -317,7 +346,8 @@ class TestMessagesList:
             _init_agent(monkeypatch, config_dir)
 
             result = runner.invoke(
-                app, ["messages", "-s", SWARM_ID, "--json"],
+                app,
+                ["messages", "-s", SWARM_ID, "--json"],
             )
 
         assert result.exit_code == 0
@@ -339,7 +369,11 @@ class TestMessagesCount:
     def test_count_display(self, mock_url, mock_count, monkeypatch):
         """Count mode shows unread, read, and total."""
         mock_count.return_value = {
-            "unread": 5, "read": 2, "archived": 0, "deleted": 0, "total": 7,
+            "unread": 5,
+            "read": 2,
+            "archived": 0,
+            "deleted": 0,
+            "total": 7,
         }
 
         with TemporaryDirectory() as tmpdir:
@@ -357,7 +391,11 @@ class TestMessagesCount:
     def test_count_json(self, mock_url, mock_count, monkeypatch):
         """Count mode with --json outputs valid JSON."""
         mock_count.return_value = {
-            "unread": 3, "read": 1, "archived": 0, "deleted": 0, "total": 4,
+            "unread": 3,
+            "read": 1,
+            "archived": 0,
+            "deleted": 0,
+            "total": 4,
         }
 
         with TemporaryDirectory() as tmpdir:
@@ -506,16 +544,30 @@ class TestMessagesArchiveAll:
     @patch("src.cli.commands.messages._fetch_inbox", new_callable=AsyncMock)
     @patch("src.cli.commands.messages._load_base_url", return_value=BASE_URL)
     def test_archive_all_success(
-        self, mock_url, mock_fetch, mock_batch, monkeypatch,
+        self,
+        mock_url,
+        mock_fetch,
+        mock_batch,
+        monkeypatch,
     ):
         """--archive-all archives read messages."""
         mock_fetch.return_value = {
             "count": 2,
             "messages": [
-                {"message_id": "msg-1", "sender_id": "a", "status": "read",
-                 "received_at": "2026-02-09T12:00:00", "content_preview": "hi"},
-                {"message_id": "msg-2", "sender_id": "b", "status": "read",
-                 "received_at": "2026-02-09T12:01:00", "content_preview": "yo"},
+                {
+                    "message_id": "msg-1",
+                    "sender_id": "a",
+                    "status": "read",
+                    "received_at": "2026-02-09T12:00:00",
+                    "content_preview": "hi",
+                },
+                {
+                    "message_id": "msg-2",
+                    "sender_id": "b",
+                    "status": "read",
+                    "received_at": "2026-02-09T12:01:00",
+                    "content_preview": "yo",
+                },
             ],
         }
         mock_batch.return_value = {"action": "archive", "updated": 2, "total": 2}
@@ -524,9 +576,7 @@ class TestMessagesArchiveAll:
             config_dir = Path(tmpdir) / "swarm"
             _init_agent(monkeypatch, config_dir)
 
-            result = runner.invoke(
-                app, ["messages", "--archive-all", "-s", SWARM_ID]
-            )
+            result = runner.invoke(app, ["messages", "--archive-all", "-s", SWARM_ID])
 
         assert result.exit_code == 0
         assert "Archived 2 of 2" in result.stdout
@@ -538,7 +588,10 @@ class TestMessagesArchiveAll:
     @patch("src.cli.commands.messages._fetch_inbox", new_callable=AsyncMock)
     @patch("src.cli.commands.messages._load_base_url", return_value=BASE_URL)
     def test_archive_all_no_read_messages(
-        self, mock_url, mock_fetch, monkeypatch,
+        self,
+        mock_url,
+        mock_fetch,
+        monkeypatch,
     ):
         """--archive-all with no read messages shows info."""
         mock_fetch.return_value = {"count": 0, "messages": []}
@@ -547,9 +600,7 @@ class TestMessagesArchiveAll:
             config_dir = Path(tmpdir) / "swarm"
             _init_agent(monkeypatch, config_dir)
 
-            result = runner.invoke(
-                app, ["messages", "--archive-all", "-s", SWARM_ID]
-            )
+            result = runner.invoke(app, ["messages", "--archive-all", "-s", SWARM_ID])
 
         assert result.exit_code == 0
         assert "No read messages to archive" in result.stdout
@@ -558,14 +609,23 @@ class TestMessagesArchiveAll:
     @patch("src.cli.commands.messages._fetch_inbox", new_callable=AsyncMock)
     @patch("src.cli.commands.messages._load_base_url", return_value=BASE_URL)
     def test_archive_all_json(
-        self, mock_url, mock_fetch, mock_batch, monkeypatch,
+        self,
+        mock_url,
+        mock_fetch,
+        mock_batch,
+        monkeypatch,
     ):
         """--archive-all --json outputs batch response."""
         mock_fetch.return_value = {
             "count": 1,
             "messages": [
-                {"message_id": "msg-1", "sender_id": "a", "status": "read",
-                 "received_at": "2026-02-09T12:00:00", "content_preview": "hi"},
+                {
+                    "message_id": "msg-1",
+                    "sender_id": "a",
+                    "status": "read",
+                    "received_at": "2026-02-09T12:00:00",
+                    "content_preview": "hi",
+                },
             ],
         }
         mock_batch.return_value = {"action": "archive", "updated": 1, "total": 1}
@@ -586,7 +646,10 @@ class TestMessagesArchiveAll:
     @patch("src.cli.commands.messages._fetch_inbox", new_callable=AsyncMock)
     @patch("src.cli.commands.messages._load_base_url", return_value=BASE_URL)
     def test_archive_all_empty_json(
-        self, mock_url, mock_fetch, monkeypatch,
+        self,
+        mock_url,
+        mock_fetch,
+        monkeypatch,
     ):
         """--archive-all --json with no messages returns zero counts."""
         mock_fetch.return_value = {"count": 0, "messages": []}

--- a/tests/test_inbox_api.py
+++ b/tests/test_inbox_api.py
@@ -8,14 +8,19 @@ import asyncio
 from datetime import datetime, timezone
 from pathlib import Path
 
-import pytest
 from fastapi.testclient import TestClient
 
 from src.server.app import create_app
-from src.server.config import AgentConfig, ServerConfig, WakeConfig, WakeEndpointConfig
+from src.server.config import (
+    AgentConfig,
+    ManagementApiConfig,
+    ServerConfig,
+    WakeConfig,
+    WakeEndpointConfig,
+)
 from src.state.database import DatabaseManager
 from src.state.models.inbox import InboxMessage, InboxStatus
-from src.state.models.outbox import OutboxMessage, OutboxStatus
+from src.state.models.outbox import OutboxMessage
 from src.state.repositories.inbox import InboxRepository
 from src.state.repositories.outbox import OutboxRepository
 
@@ -26,44 +31,82 @@ MSG_3 = "aaa00000-0000-0000-0000-000000000003"
 
 _NO_WAKE = WakeConfig(enabled=False, endpoint="")
 _NO_WAKE_EP = WakeEndpointConfig(enabled=False)
+_MANAGEMENT_TOKEN = "test-management-token"
+_MANAGEMENT_HEADERS = {"Authorization": f"Bearer {_MANAGEMENT_TOKEN}"}
 
 
 def _cfg(agent_config: AgentConfig, db_path: Path) -> ServerConfig:
-    return ServerConfig(agent=agent_config, db_path=db_path, wake=_NO_WAKE, wake_endpoint=_NO_WAKE_EP)
+    return ServerConfig(
+        agent=agent_config,
+        db_path=db_path,
+        management_api=ManagementApiConfig(
+            enabled=True,
+            token=_MANAGEMENT_TOKEN,
+        ),
+        wake=_NO_WAKE,
+        wake_endpoint=_NO_WAKE_EP,
+    )
+
+
+def _client(agent_config: AgentConfig, db_path: Path) -> TestClient:
+    """Create a client authorized for the private management API."""
+    return TestClient(
+        create_app(_cfg(agent_config, db_path)),
+        headers=_MANAGEMENT_HEADERS,
+    )
 
 
 def _seed_inbox(db_path: Path) -> None:
     """Seed three inbox messages: 2 unread, 1 read."""
+
     async def _seed() -> None:
         db = DatabaseManager(db_path)
         await db.initialize()
         async with db.connection() as conn:
             repo = InboxRepository(conn)
-            await repo.insert(InboxMessage(
-                message_id=MSG_1, swarm_id=SWARM_ID, sender_id="alpha",
-                message_type="message", content='{"text":"hello from alpha"}',
-                received_at=datetime(2026, 2, 9, 10, 0, 0, tzinfo=timezone.utc),
-            ))
-            await repo.insert(InboxMessage(
-                message_id=MSG_2, swarm_id=SWARM_ID, sender_id="beta",
-                message_type="message", content='{"text":"hello from beta"}',
-                received_at=datetime(2026, 2, 9, 11, 0, 0, tzinfo=timezone.utc),
-            ))
-            await repo.insert(InboxMessage(
-                message_id=MSG_3, swarm_id=SWARM_ID, sender_id="gamma",
-                message_type="message", content='{"text":"hello from gamma"}',
-                received_at=datetime(2026, 2, 9, 12, 0, 0, tzinfo=timezone.utc),
-            ))
+            await repo.insert(
+                InboxMessage(
+                    message_id=MSG_1,
+                    swarm_id=SWARM_ID,
+                    sender_id="alpha",
+                    message_type="message",
+                    content='{"text":"hello from alpha"}',
+                    received_at=datetime(2026, 2, 9, 10, 0, 0, tzinfo=timezone.utc),
+                )
+            )
+            await repo.insert(
+                InboxMessage(
+                    message_id=MSG_2,
+                    swarm_id=SWARM_ID,
+                    sender_id="beta",
+                    message_type="message",
+                    content='{"text":"hello from beta"}',
+                    received_at=datetime(2026, 2, 9, 11, 0, 0, tzinfo=timezone.utc),
+                )
+            )
+            await repo.insert(
+                InboxMessage(
+                    message_id=MSG_3,
+                    swarm_id=SWARM_ID,
+                    sender_id="gamma",
+                    message_type="message",
+                    content='{"text":"hello from gamma"}',
+                    received_at=datetime(2026, 2, 9, 12, 0, 0, tzinfo=timezone.utc),
+                )
+            )
             await repo.mark_read(MSG_3)
         await db.close()
+
     asyncio.run(_seed())
 
 
 class TestInboxList:
-    def test_list_unread_default(self, agent_config: AgentConfig, tmp_path: Path) -> None:
+    def test_list_unread_default(
+        self, agent_config: AgentConfig, tmp_path: Path
+    ) -> None:
         db_path = tmp_path / "list.db"
         _seed_inbox(db_path)
-        with TestClient(create_app(_cfg(agent_config, db_path))) as c:
+        with _client(agent_config, db_path) as c:
             resp = c.get("/api/inbox", params={"swarm_id": SWARM_ID})
         assert resp.status_code == 200
         data = resp.json()
@@ -73,7 +116,7 @@ class TestInboxList:
     def test_list_read(self, agent_config: AgentConfig, tmp_path: Path) -> None:
         db_path = tmp_path / "list_read.db"
         _seed_inbox(db_path)
-        with TestClient(create_app(_cfg(agent_config, db_path))) as c:
+        with _client(agent_config, db_path) as c:
             resp = c.get("/api/inbox", params={"swarm_id": SWARM_ID, "status": "read"})
         assert resp.status_code == 200
         assert resp.json()["count"] == 1
@@ -82,48 +125,69 @@ class TestInboxList:
     def test_list_all(self, agent_config: AgentConfig, tmp_path: Path) -> None:
         db_path = tmp_path / "list_all.db"
         _seed_inbox(db_path)
-        with TestClient(create_app(_cfg(agent_config, db_path))) as c:
+        with _client(agent_config, db_path) as c:
             resp = c.get("/api/inbox", params={"swarm_id": SWARM_ID, "status": "all"})
         assert resp.status_code == 200
         assert resp.json()["count"] == 3
 
-    def test_list_invalid_status(self, agent_config: AgentConfig, tmp_path: Path) -> None:
+    def test_list_invalid_status(
+        self, agent_config: AgentConfig, tmp_path: Path
+    ) -> None:
         db_path = tmp_path / "list_bad.db"
         _seed_inbox(db_path)
-        with TestClient(create_app(_cfg(agent_config, db_path))) as c:
+        with _client(agent_config, db_path) as c:
             resp = c.get("/api/inbox", params={"status": "bogus"})
         assert resp.status_code == 400
 
-    def test_list_respects_limit(self, agent_config: AgentConfig, tmp_path: Path) -> None:
+    def test_list_respects_limit(
+        self, agent_config: AgentConfig, tmp_path: Path
+    ) -> None:
         db_path = tmp_path / "list_limit.db"
         _seed_inbox(db_path)
-        with TestClient(create_app(_cfg(agent_config, db_path))) as c:
-            resp = c.get("/api/inbox", params={"swarm_id": SWARM_ID, "status": "all", "limit": 1})
+        with _client(agent_config, db_path) as c:
+            resp = c.get(
+                "/api/inbox", params={"swarm_id": SWARM_ID, "status": "all", "limit": 1}
+            )
         assert resp.status_code == 200
         assert resp.json()["count"] == 1
 
     def test_list_empty_swarm(self, agent_config: AgentConfig, tmp_path: Path) -> None:
         db_path = tmp_path / "list_empty.db"
         _seed_inbox(db_path)
-        with TestClient(create_app(_cfg(agent_config, db_path))) as c:
-            resp = c.get("/api/inbox", params={"swarm_id": "00000000-0000-0000-0000-000000000000"})
+        with _client(agent_config, db_path) as c:
+            resp = c.get(
+                "/api/inbox",
+                params={"swarm_id": "00000000-0000-0000-0000-000000000000"},
+            )
         assert resp.status_code == 200
         assert resp.json()["count"] == 0
 
-    def test_list_message_fields(self, agent_config: AgentConfig, tmp_path: Path) -> None:
+    def test_list_message_fields(
+        self, agent_config: AgentConfig, tmp_path: Path
+    ) -> None:
         db_path = tmp_path / "list_fields.db"
         _seed_inbox(db_path)
-        with TestClient(create_app(_cfg(agent_config, db_path))) as c:
-            resp = c.get("/api/inbox", params={"swarm_id": SWARM_ID, "status": "all", "limit": 1})
+        with _client(agent_config, db_path) as c:
+            resp = c.get(
+                "/api/inbox", params={"swarm_id": SWARM_ID, "status": "all", "limit": 1}
+            )
         msg = resp.json()["messages"][0]
-        for field in ("message_id", "swarm_id", "sender_id", "message_type", "status", "received_at", "content_preview"):
+        for field in (
+            "message_id",
+            "swarm_id",
+            "sender_id",
+            "message_type",
+            "status",
+            "received_at",
+            "content_preview",
+        ):
             assert field in msg
 
     def test_list_by_sender(self, agent_config: AgentConfig, tmp_path: Path) -> None:
         """sender_id filter returns only messages from that sender."""
         db_path = tmp_path / "list_sender.db"
         _seed_inbox(db_path)
-        with TestClient(create_app(_cfg(agent_config, db_path))) as c:
+        with _client(agent_config, db_path) as c:
             resp = c.get("/api/inbox", params={"sender_id": "alpha", "status": "all"})
         assert resp.status_code == 200
         data = resp.json()
@@ -135,7 +199,7 @@ class TestInboxCount:
     def test_count(self, agent_config: AgentConfig, tmp_path: Path) -> None:
         db_path = tmp_path / "count.db"
         _seed_inbox(db_path)
-        with TestClient(create_app(_cfg(agent_config, db_path))) as c:
+        with _client(agent_config, db_path) as c:
             resp = c.get("/api/inbox/count", params={"swarm_id": SWARM_ID})
         assert resp.status_code == 200
         data = resp.json()
@@ -148,26 +212,33 @@ class TestInboxCount:
     def test_count_empty(self, agent_config: AgentConfig, tmp_path: Path) -> None:
         db_path = tmp_path / "count_empty.db"
         _seed_inbox(db_path)
-        with TestClient(create_app(_cfg(agent_config, db_path))) as c:
-            resp = c.get("/api/inbox/count", params={"swarm_id": "00000000-0000-0000-0000-000000000000"})
+        with _client(agent_config, db_path) as c:
+            resp = c.get(
+                "/api/inbox/count",
+                params={"swarm_id": "00000000-0000-0000-0000-000000000000"},
+            )
         assert resp.status_code == 200
         assert resp.json()["total"] == 0
 
-    def test_count_without_swarm_id(self, agent_config: AgentConfig, tmp_path: Path) -> None:
+    def test_count_without_swarm_id(
+        self, agent_config: AgentConfig, tmp_path: Path
+    ) -> None:
         """Count without swarm_id returns cross-swarm totals."""
         db_path = tmp_path / "count_no_swarm.db"
         _seed_inbox(db_path)
-        with TestClient(create_app(_cfg(agent_config, db_path))) as c:
+        with _client(agent_config, db_path) as c:
             resp = c.get("/api/inbox/count")
         assert resp.status_code == 200
         assert resp.json()["total"] == 3
 
 
 class TestInboxGetMessage:
-    def test_get_auto_marks_read(self, agent_config: AgentConfig, tmp_path: Path) -> None:
+    def test_get_auto_marks_read(
+        self, agent_config: AgentConfig, tmp_path: Path
+    ) -> None:
         db_path = tmp_path / "get_auto.db"
         _seed_inbox(db_path)
-        with TestClient(create_app(_cfg(agent_config, db_path))) as c:
+        with _client(agent_config, db_path) as c:
             resp = c.get(f"/api/inbox/{MSG_1}")
         assert resp.status_code == 200
         data = resp.json()
@@ -178,7 +249,7 @@ class TestInboxGetMessage:
     def test_get_already_read(self, agent_config: AgentConfig, tmp_path: Path) -> None:
         db_path = tmp_path / "get_read.db"
         _seed_inbox(db_path)
-        with TestClient(create_app(_cfg(agent_config, db_path))) as c:
+        with _client(agent_config, db_path) as c:
             resp = c.get(f"/api/inbox/{MSG_3}")
         assert resp.status_code == 200
         assert resp.json()["status"] == "read"
@@ -186,7 +257,7 @@ class TestInboxGetMessage:
     def test_get_not_found(self, agent_config: AgentConfig, tmp_path: Path) -> None:
         db_path = tmp_path / "get_404.db"
         _seed_inbox(db_path)
-        with TestClient(create_app(_cfg(agent_config, db_path))) as c:
+        with _client(agent_config, db_path) as c:
             resp = c.get("/api/inbox/ffffffff-ffff-ffff-ffff-ffffffffffff")
         assert resp.status_code == 404
 
@@ -195,23 +266,27 @@ class TestInboxMarkRead:
     def test_mark_read(self, agent_config: AgentConfig, tmp_path: Path) -> None:
         db_path = tmp_path / "mark_read.db"
         _seed_inbox(db_path)
-        with TestClient(create_app(_cfg(agent_config, db_path))) as c:
+        with _client(agent_config, db_path) as c:
             resp = c.post(f"/api/inbox/{MSG_1}/read")
         assert resp.status_code == 200
         assert resp.json()["status"] == "read"
 
-    def test_mark_read_idempotent(self, agent_config: AgentConfig, tmp_path: Path) -> None:
+    def test_mark_read_idempotent(
+        self, agent_config: AgentConfig, tmp_path: Path
+    ) -> None:
         db_path = tmp_path / "mark_read_idem.db"
         _seed_inbox(db_path)
-        with TestClient(create_app(_cfg(agent_config, db_path))) as c:
+        with _client(agent_config, db_path) as c:
             c.post(f"/api/inbox/{MSG_1}/read")
             resp = c.post(f"/api/inbox/{MSG_1}/read")
         assert resp.status_code == 200
 
-    def test_mark_read_not_found(self, agent_config: AgentConfig, tmp_path: Path) -> None:
+    def test_mark_read_not_found(
+        self, agent_config: AgentConfig, tmp_path: Path
+    ) -> None:
         db_path = tmp_path / "mark_read_404.db"
         _seed_inbox(db_path)
-        with TestClient(create_app(_cfg(agent_config, db_path))) as c:
+        with _client(agent_config, db_path) as c:
             resp = c.post("/api/inbox/ffffffff-ffff-ffff-ffff-ffffffffffff/read")
         assert resp.status_code == 404
 
@@ -220,7 +295,7 @@ class TestInboxArchive:
     def test_archive(self, agent_config: AgentConfig, tmp_path: Path) -> None:
         db_path = tmp_path / "archive.db"
         _seed_inbox(db_path)
-        with TestClient(create_app(_cfg(agent_config, db_path))) as c:
+        with _client(agent_config, db_path) as c:
             resp = c.post(f"/api/inbox/{MSG_1}/archive")
         assert resp.status_code == 200
         assert resp.json()["status"] == "archived"
@@ -228,7 +303,7 @@ class TestInboxArchive:
     def test_archive_not_found(self, agent_config: AgentConfig, tmp_path: Path) -> None:
         db_path = tmp_path / "archive_404.db"
         _seed_inbox(db_path)
-        with TestClient(create_app(_cfg(agent_config, db_path))) as c:
+        with _client(agent_config, db_path) as c:
             resp = c.post("/api/inbox/ffffffff-ffff-ffff-ffff-ffffffffffff/archive")
         assert resp.status_code == 404
 
@@ -237,7 +312,7 @@ class TestInboxDelete:
     def test_delete(self, agent_config: AgentConfig, tmp_path: Path) -> None:
         db_path = tmp_path / "delete.db"
         _seed_inbox(db_path)
-        with TestClient(create_app(_cfg(agent_config, db_path))) as c:
+        with _client(agent_config, db_path) as c:
             resp = c.post(f"/api/inbox/{MSG_1}/delete")
         assert resp.status_code == 200
         assert resp.json()["status"] == "deleted"
@@ -245,14 +320,16 @@ class TestInboxDelete:
     def test_delete_not_found(self, agent_config: AgentConfig, tmp_path: Path) -> None:
         db_path = tmp_path / "delete_404.db"
         _seed_inbox(db_path)
-        with TestClient(create_app(_cfg(agent_config, db_path))) as c:
+        with _client(agent_config, db_path) as c:
             resp = c.post("/api/inbox/ffffffff-ffff-ffff-ffff-ffffffffffff/delete")
         assert resp.status_code == 404
 
-    def test_delete_removes_from_list(self, agent_config: AgentConfig, tmp_path: Path) -> None:
+    def test_delete_removes_from_list(
+        self, agent_config: AgentConfig, tmp_path: Path
+    ) -> None:
         db_path = tmp_path / "delete_list.db"
         _seed_inbox(db_path)
-        with TestClient(create_app(_cfg(agent_config, db_path))) as c:
+        with _client(agent_config, db_path) as c:
             c.post(f"/api/inbox/{MSG_1}/delete")
             resp = c.get("/api/inbox", params={"swarm_id": SWARM_ID, "status": "all"})
         assert resp.json()["count"] == 2
@@ -264,8 +341,11 @@ class TestInboxBatch:
     def test_batch_read(self, agent_config: AgentConfig, tmp_path: Path) -> None:
         db_path = tmp_path / "batch_read.db"
         _seed_inbox(db_path)
-        with TestClient(create_app(_cfg(agent_config, db_path))) as c:
-            resp = c.post("/api/inbox/batch", json={"message_ids": [MSG_1, MSG_2], "action": "read"})
+        with _client(agent_config, db_path) as c:
+            resp = c.post(
+                "/api/inbox/batch",
+                json={"message_ids": [MSG_1, MSG_2], "action": "read"},
+            )
         assert resp.status_code == 200
         data = resp.json()
         assert data["action"] == "read"
@@ -275,52 +355,79 @@ class TestInboxBatch:
     def test_batch_archive(self, agent_config: AgentConfig, tmp_path: Path) -> None:
         db_path = tmp_path / "batch_archive.db"
         _seed_inbox(db_path)
-        with TestClient(create_app(_cfg(agent_config, db_path))) as c:
-            resp = c.post("/api/inbox/batch", json={"message_ids": [MSG_1], "action": "archive"})
+        with _client(agent_config, db_path) as c:
+            resp = c.post(
+                "/api/inbox/batch", json={"message_ids": [MSG_1], "action": "archive"}
+            )
         assert resp.status_code == 200
         assert resp.json()["updated"] == 1
 
     def test_batch_delete(self, agent_config: AgentConfig, tmp_path: Path) -> None:
         db_path = tmp_path / "batch_delete.db"
         _seed_inbox(db_path)
-        with TestClient(create_app(_cfg(agent_config, db_path))) as c:
-            resp = c.post("/api/inbox/batch", json={"message_ids": [MSG_1, MSG_2, MSG_3], "action": "delete"})
+        with _client(agent_config, db_path) as c:
+            resp = c.post(
+                "/api/inbox/batch",
+                json={"message_ids": [MSG_1, MSG_2, MSG_3], "action": "delete"},
+            )
         assert resp.status_code == 200
         assert resp.json()["updated"] == 3
 
-    def test_batch_read_skips_already_read(self, agent_config: AgentConfig, tmp_path: Path) -> None:
+    def test_batch_read_skips_already_read(
+        self, agent_config: AgentConfig, tmp_path: Path
+    ) -> None:
         """Batch read with transition guard: MSG_3 is already read, should skip."""
         db_path = tmp_path / "batch_guard.db"
         _seed_inbox(db_path)
-        with TestClient(create_app(_cfg(agent_config, db_path))) as c:
-            resp = c.post("/api/inbox/batch", json={"message_ids": [MSG_1, MSG_3], "action": "read"})
+        with _client(agent_config, db_path) as c:
+            resp = c.post(
+                "/api/inbox/batch",
+                json={"message_ids": [MSG_1, MSG_3], "action": "read"},
+            )
         assert resp.status_code == 200
         assert resp.json()["updated"] == 1  # only MSG_1 (unread->read)
 
-    def test_batch_empty_ids_rejected(self, agent_config: AgentConfig, tmp_path: Path) -> None:
+    def test_batch_empty_ids_rejected(
+        self, agent_config: AgentConfig, tmp_path: Path
+    ) -> None:
         db_path = tmp_path / "batch_empty.db"
         _seed_inbox(db_path)
-        with TestClient(create_app(_cfg(agent_config, db_path))) as c:
-            resp = c.post("/api/inbox/batch", json={"message_ids": [], "action": "read"})
+        with _client(agent_config, db_path) as c:
+            resp = c.post(
+                "/api/inbox/batch", json={"message_ids": [], "action": "read"}
+            )
         assert resp.status_code == 422
 
 
 class TestMessageReceiveInbox:
-    def test_message_goes_to_inbox(self, agent_config: AgentConfig, tmp_path: Path) -> None:
+    def test_message_goes_to_inbox(
+        self, agent_config: AgentConfig, tmp_path: Path
+    ) -> None:
         """POST /swarm/message inserts into inbox table, not message_queue."""
         db_path = tmp_path / "receive.db"
         config = _cfg(agent_config, db_path)
         with TestClient(create_app(config)) as c:
-            resp = c.post("/swarm/message", json={
-                "protocol_version": "0.1.0",
-                "message_id": "550e8400-e29b-41d4-a716-446655440000",
-                "timestamp": "2026-02-09T14:30:00.000Z",
-                "sender": {"agent_id": "sender-123", "endpoint": "https://sender.example.com"},
-                "recipient": "test-agent-001",
-                "swarm_id": "660e8400-e29b-41d4-a716-446655440001",
-                "type": "message", "content": "Hello",
-                "signature": "dGVzdC1zaWduYXR1cmUtYmFzZTY0",
-            }, headers={"Content-Type": "application/json", "X-Agent-ID": "sender-123"})
+            resp = c.post(
+                "/swarm/message",
+                json={
+                    "protocol_version": "0.1.0",
+                    "message_id": "550e8400-e29b-41d4-a716-446655440000",
+                    "timestamp": "2026-02-09T14:30:00.000Z",
+                    "sender": {
+                        "agent_id": "sender-123",
+                        "endpoint": "https://sender.example.com",
+                    },
+                    "recipient": "test-agent-001",
+                    "swarm_id": "660e8400-e29b-41d4-a716-446655440001",
+                    "type": "message",
+                    "content": "Hello",
+                    "signature": "dGVzdC1zaWduYXR1cmUtYmFzZTY0",
+                },
+                headers={
+                    "Content-Type": "application/json",
+                    "X-Agent-ID": "sender-123",
+                },
+            )
         assert resp.status_code == 200
         assert resp.json()["status"] == "queued"
 
@@ -335,9 +442,12 @@ class TestMessageReceiveInbox:
                 assert msg.status == InboxStatus.UNREAD
                 assert msg.sender_id == "sender-123"
             await db.close()
+
         asyncio.run(_check())
 
-    def test_duplicate_message_idempotent(self, agent_config: AgentConfig, tmp_path: Path) -> None:
+    def test_duplicate_message_idempotent(
+        self, agent_config: AgentConfig, tmp_path: Path
+    ) -> None:
         """Re-posting same message_id does not raise an error."""
         db_path = tmp_path / "dup.db"
         config = _cfg(agent_config, db_path)
@@ -345,37 +455,61 @@ class TestMessageReceiveInbox:
             "protocol_version": "0.1.0",
             "message_id": "550e8400-e29b-41d4-a716-446655440000",
             "timestamp": "2026-02-09T14:30:00.000Z",
-            "sender": {"agent_id": "sender-123", "endpoint": "https://sender.example.com"},
+            "sender": {
+                "agent_id": "sender-123",
+                "endpoint": "https://sender.example.com",
+            },
             "recipient": "test-agent-001",
             "swarm_id": "660e8400-e29b-41d4-a716-446655440001",
-            "type": "message", "content": "Hello",
+            "type": "message",
+            "content": "Hello",
             "signature": "dGVzdC1zaWduYXR1cmUtYmFzZTY0",
         }
         with TestClient(create_app(config)) as c:
-            r1 = c.post("/swarm/message", json=msg, headers={"Content-Type": "application/json", "X-Agent-ID": "x"})
-            r2 = c.post("/swarm/message", json=msg, headers={"Content-Type": "application/json", "X-Agent-ID": "x"})
+            r1 = c.post(
+                "/swarm/message",
+                json=msg,
+                headers={"Content-Type": "application/json", "X-Agent-ID": "x"},
+            )
+            r2 = c.post(
+                "/swarm/message",
+                json=msg,
+                headers={"Content-Type": "application/json", "X-Agent-ID": "x"},
+            )
         assert r1.status_code == 200
         assert r2.status_code == 200
 
 
 def _seed_outbox(db_path: Path) -> None:
     """Seed two outbox messages."""
+
     async def _seed() -> None:
         db = DatabaseManager(db_path)
         await db.initialize()
         async with db.connection() as conn:
             repo = OutboxRepository(conn)
-            await repo.insert(OutboxMessage(
-                message_id="out-001", swarm_id=SWARM_ID, recipient_id="beta",
-                message_type="message", content='{"text":"sent to beta"}',
-                sent_at=datetime(2026, 2, 9, 10, 0, 0, tzinfo=timezone.utc),
-            ))
-            await repo.insert(OutboxMessage(
-                message_id="out-002", swarm_id=SWARM_ID, recipient_id="gamma",
-                message_type="message", content='{"text":"sent to gamma"}',
-                sent_at=datetime(2026, 2, 9, 11, 0, 0, tzinfo=timezone.utc),
-            ))
+            await repo.insert(
+                OutboxMessage(
+                    message_id="out-001",
+                    swarm_id=SWARM_ID,
+                    recipient_id="beta",
+                    message_type="message",
+                    content='{"text":"sent to beta"}',
+                    sent_at=datetime(2026, 2, 9, 10, 0, 0, tzinfo=timezone.utc),
+                )
+            )
+            await repo.insert(
+                OutboxMessage(
+                    message_id="out-002",
+                    swarm_id=SWARM_ID,
+                    recipient_id="gamma",
+                    message_type="message",
+                    content='{"text":"sent to gamma"}',
+                    sent_at=datetime(2026, 2, 9, 11, 0, 0, tzinfo=timezone.utc),
+                )
+            )
         await db.close()
+
     asyncio.run(_seed())
 
 
@@ -383,7 +517,7 @@ class TestOutboxList:
     def test_list_sent(self, agent_config: AgentConfig, tmp_path: Path) -> None:
         db_path = tmp_path / "outbox_list.db"
         _seed_outbox(db_path)
-        with TestClient(create_app(_cfg(agent_config, db_path))) as c:
+        with _client(agent_config, db_path) as c:
             resp = c.get("/api/outbox", params={"swarm_id": SWARM_ID})
         assert resp.status_code == 200
         data = resp.json()
@@ -392,8 +526,11 @@ class TestOutboxList:
     def test_list_empty(self, agent_config: AgentConfig, tmp_path: Path) -> None:
         db_path = tmp_path / "outbox_empty.db"
         _seed_outbox(db_path)
-        with TestClient(create_app(_cfg(agent_config, db_path))) as c:
-            resp = c.get("/api/outbox", params={"swarm_id": "00000000-0000-0000-0000-000000000000"})
+        with _client(agent_config, db_path) as c:
+            resp = c.get(
+                "/api/outbox",
+                params={"swarm_id": "00000000-0000-0000-0000-000000000000"},
+            )
         assert resp.status_code == 200
         assert resp.json()["count"] == 0
 
@@ -402,15 +539,17 @@ class TestOutboxCount:
     def test_count(self, agent_config: AgentConfig, tmp_path: Path) -> None:
         db_path = tmp_path / "outbox_count.db"
         _seed_outbox(db_path)
-        with TestClient(create_app(_cfg(agent_config, db_path))) as c:
+        with _client(agent_config, db_path) as c:
             resp = c.get("/api/outbox/count", params={"swarm_id": SWARM_ID})
         assert resp.status_code == 200
         data = resp.json()
         assert data["sent"] == 2
         assert data["total"] == 2
 
-    def test_count_requires_swarm_id(self, agent_config: AgentConfig, tmp_path: Path) -> None:
+    def test_count_requires_swarm_id(
+        self, agent_config: AgentConfig, tmp_path: Path
+    ) -> None:
         db_path = tmp_path / "outbox_count_no_swarm.db"
-        with TestClient(create_app(_cfg(agent_config, db_path))) as c:
+        with _client(agent_config, db_path) as c:
             resp = c.get("/api/outbox/count")
         assert resp.status_code == 422

--- a/tests/test_management_api_auth.py
+++ b/tests/test_management_api_auth.py
@@ -1,0 +1,96 @@
+"""Access-control tests for the private inbox/outbox management API."""
+
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src.server.app import create_app
+from src.server.config import (
+    AgentConfig,
+    ManagementApiConfig,
+    ServerConfig,
+    WakeConfig,
+    WakeEndpointConfig,
+    load_config_from_env,
+)
+
+_TOKEN = "test-management-token"
+
+
+def _config(
+    agent: AgentConfig,
+    db_path: Path,
+    *,
+    enabled: bool = True,
+) -> ServerConfig:
+    return ServerConfig(
+        agent=agent,
+        db_path=db_path,
+        management_api=ManagementApiConfig(enabled=enabled, token=_TOKEN),
+        wake=WakeConfig(enabled=False, endpoint=""),
+        wake_endpoint=WakeEndpointConfig(enabled=False),
+    )
+
+
+@pytest.mark.parametrize("path", ["/api/inbox", "/api/outbox"])
+@pytest.mark.parametrize(
+    "authorization",
+    [None, "", "Basic dGVzdDp0ZXN0", "Bearer", "Bearer wrong-token"],
+)
+def test_private_routes_reject_invalid_authorization(
+    agent_config: AgentConfig,
+    tmp_path: Path,
+    path: str,
+    authorization: str | None,
+) -> None:
+    headers = {"Authorization": authorization} if authorization else {}
+    with TestClient(create_app(_config(agent_config, tmp_path / "auth.db"))) as client:
+        response = client.get(path, headers=headers)
+
+    assert response.status_code == 401
+    assert response.headers["www-authenticate"] == "Bearer"
+    assert set(response.json()) == {"detail"}
+
+
+@pytest.mark.parametrize("path", ["/api/inbox", "/api/outbox"])
+def test_private_routes_accept_valid_bearer_token(
+    agent_config: AgentConfig,
+    tmp_path: Path,
+    path: str,
+) -> None:
+    with TestClient(create_app(_config(agent_config, tmp_path / "valid.db"))) as client:
+        response = client.get(
+            path,
+            headers={"Authorization": f"Bearer {_TOKEN}"},
+        )
+
+    assert response.status_code == 200
+    assert response.json() == {"count": 0, "messages": []}
+
+
+@pytest.mark.parametrize("path", ["/api/inbox", "/api/outbox"])
+def test_private_routes_are_absent_when_disabled(
+    agent_config: AgentConfig,
+    tmp_path: Path,
+    path: str,
+) -> None:
+    with TestClient(
+        create_app(_config(agent_config, tmp_path / "disabled.db", enabled=False))
+    ) as client:
+        response = client.get(path)
+
+    assert response.status_code == 404
+
+
+def test_enabled_management_api_requires_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("AGENT_ID", "test-agent")
+    monkeypatch.setenv("AGENT_ENDPOINT", "https://test.example.com/swarm")
+    monkeypatch.setenv("AGENT_PUBLIC_KEY", "test-public-key")
+    monkeypatch.setenv("MANAGEMENT_API_ENABLED", "true")
+    monkeypatch.delenv("MANAGEMENT_API_TOKEN", raising=False)
+
+    with pytest.raises(ValueError, match="MANAGEMENT_API_TOKEN required"):
+        load_config_from_env()


### PR DESCRIPTION
## Summary

- disable the inbox/outbox management API by default;
- require a constant-time Bearer-token check on every management route when enabled;
- fail server startup if management access is enabled without a token;
- have the CLI read its credential from a dedicated local `management.token` file;
- create the local state directory as `0700` and configuration as `0600`;
- document the server/CLI provisioning contract.

## Security boundary

`/api/inbox` exposes received-message previews and lifecycle mutations, while
`/api/outbox` exposes sent-message previews and delivery errors. These routes
previously mounted without authentication whenever the server started. This
change makes absence the default and applies one shared authorization dependency
to both routers when explicitly enabled.

Credentials are never included in request logs or application errors. Invalid,
missing, malformed, and wrong-scheme credentials all return `401` with a Bearer
challenge and no message fields.

## Validation

- focused management, inbox/outbox, CLI configuration, and CLI message tests:
  91 passed;
- full suite: 576 passed;
- Ruff checks on the changed surface (excluding the repository's pre-existing
  `E402` integrity-import and line-length findings);
- `git diff --check`.
