### PR TITLE
fix(server): verify inbound message signatures

### DIFF
--- a/src/server/message_auth.py
+++ b/src/server/message_auth.py
@@ -1,0 +1,109 @@
+"""Authentication and authorization for inbound swarm messages."""
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Literal
+from uuid import UUID
+
+import aiosqlite
+
+from src.client.crypto import public_key_from_base64, verify_signature
+from src.client.exceptions import SignatureError
+from src.server.models.requests import MessageRequest
+from src.state.repositories.membership import MembershipRepository
+
+MessageAuthenticationCode = Literal[
+    "INVALID_FORMAT",
+    "INVALID_SIGNATURE",
+    "NOT_AUTHORIZED",
+    "SWARM_NOT_FOUND",
+    "INTERNAL_ERROR",
+]
+
+
+@dataclass(frozen=True)
+class MessageAuthenticationError(Exception):
+    """Fail-closed inbound-message rejection with protocol error metadata."""
+
+    status_code: int
+    code: MessageAuthenticationCode
+    reason: str
+
+
+async def authenticate_message(
+    conn: aiosqlite.Connection,
+    body: MessageRequest,
+    *,
+    local_agent_id: str,
+    sender_header: str | None,
+    protocol_header: str | None,
+) -> None:
+    """Verify transport claims, membership, recipient, and Ed25519 signature."""
+    if sender_header != body.sender.agent_id:
+        raise _not_authorized("X-Agent-ID does not match the signed sender")
+    if protocol_header != body.protocol_version:
+        raise _not_authorized(
+            "X-Swarm-Protocol does not match the message protocol version"
+        )
+    if body.recipient not in (local_agent_id, "broadcast"):
+        raise _not_authorized("message recipient is not this agent or broadcast")
+
+    swarm = await MembershipRepository(conn).get_swarm(body.swarm_id)
+    if swarm is None:
+        raise MessageAuthenticationError(
+            status_code=404,
+            code="SWARM_NOT_FOUND",
+            reason="message references an unknown swarm",
+        )
+
+    sender = next(
+        (member for member in swarm.members if member.agent_id == body.sender.agent_id),
+        None,
+    )
+    if sender is None:
+        raise _not_authorized("sender is not a member of the referenced swarm")
+    if sender.endpoint.rstrip("/") != body.sender.endpoint.rstrip("/"):
+        raise _not_authorized("sender endpoint does not match registered membership")
+
+    try:
+        timestamp = datetime.fromisoformat(body.timestamp.replace("Z", "+00:00"))
+        if timestamp.tzinfo is None:
+            raise ValueError("timestamp must include a timezone")
+        public_key = public_key_from_base64(sender.public_key)
+    except ValueError as exc:
+        raise MessageAuthenticationError(
+            status_code=400,
+            code="INVALID_FORMAT",
+            reason=f"message timestamp is invalid: {exc}",
+        ) from exc
+    except SignatureError as exc:
+        raise MessageAuthenticationError(
+            status_code=500,
+            code="INTERNAL_ERROR",
+            reason="registered sender public key is invalid",
+        ) from exc
+
+    is_valid = verify_signature(
+        public_key,
+        body.signature,
+        UUID(body.message_id),
+        timestamp,
+        UUID(body.swarm_id),
+        body.recipient,
+        body.type,
+        body.content,
+    )
+    if not is_valid:
+        raise MessageAuthenticationError(
+            status_code=401,
+            code="INVALID_SIGNATURE",
+            reason="Ed25519 signature verification failed",
+        )
+
+
+def _not_authorized(reason: str) -> MessageAuthenticationError:
+    return MessageAuthenticationError(
+        status_code=403,
+        code="NOT_AUTHORIZED",
+        reason=reason,
+    )

--- a/src/server/routes/message.py
+++ b/src/server/routes/message.py
@@ -1,4 +1,5 @@
 """POST /swarm/message endpoint handler."""
+
 import logging
 import sqlite3
 from datetime import datetime, timezone
@@ -6,14 +7,23 @@ from typing import Optional
 
 import toon
 from fastapi import APIRouter, Request, status
+from fastapi.responses import JSONResponse
 
+from src.claude.wake_trigger import WakeTrigger
+from src.server.message_auth import (
+    MessageAuthenticationError,
+    authenticate_message,
+)
 from src.server.models.requests import MessageRequest
-from src.server.models.responses import MessageQueuedResponse
+from src.server.models.responses import (
+    ErrorDetail,
+    ErrorResponse,
+    MessageQueuedResponse,
+)
 from src.server.system_dispatch import dispatch_system_message
 from src.state.database import DatabaseManager
 from src.state.models.inbox import InboxMessage, InboxStatus
 from src.state.repositories.inbox import InboxRepository
-from src.claude.wake_trigger import WakeTrigger
 
 logger = logging.getLogger(__name__)
 
@@ -29,8 +39,9 @@ def create_message_router(db: DatabaseManager, local_agent_id: str) -> APIRouter
         tags=["messages"],
     )
     async def receive_message(
-        request: Request, body: MessageRequest,
-    ) -> MessageQueuedResponse:
+        request: Request,
+        body: MessageRequest,
+    ) -> MessageQueuedResponse | JSONResponse:
         """Receive and persist a message from another agent.
 
         Idempotent: re-posting a message with the same message_id
@@ -39,27 +50,62 @@ def create_message_router(db: DatabaseManager, local_agent_id: str) -> APIRouter
         After persistence, the wake trigger (if configured) evaluates
         whether to WAKE, QUEUE, or SKIP the message.
         """
-        msg_dict = body.model_dump(exclude_none=True)
-        toon_content = toon.encode(msg_dict)
-
-        inbox_msg = InboxMessage(
-            message_id=body.message_id,
-            swarm_id=body.swarm_id,
-            sender_id=body.sender.agent_id,
-            recipient_id=body.recipient,
-            message_type=body.type,
-            content=toon_content,
-            received_at=datetime.now(timezone.utc),
-            status=InboxStatus.UNREAD,
-        )
         async with db.connection() as conn:
+            try:
+                await authenticate_message(
+                    conn,
+                    body,
+                    local_agent_id=local_agent_id,
+                    sender_header=request.headers.get("X-Agent-ID"),
+                    protocol_header=request.headers.get("X-Swarm-Protocol"),
+                )
+            except MessageAuthenticationError as exc:
+                log_method = logger.error if exc.status_code == 500 else logger.warning
+                log_method(
+                    "Message rejected: code=%s message=%s swarm=%s sender=%s reason=%s",
+                    exc.code,
+                    body.message_id,
+                    body.swarm_id,
+                    body.sender.agent_id,
+                    exc.reason,
+                )
+                error = ErrorResponse(
+                    error=ErrorDetail(
+                        code=exc.code,
+                        message="Inbound message authentication failed",
+                    )
+                )
+                return JSONResponse(
+                    status_code=exc.status_code,
+                    content=error.model_dump(),
+                )
+
+            msg_dict = body.model_dump(exclude_none=True)
+            toon_content = toon.encode(msg_dict)
+            inbox_msg = InboxMessage(
+                message_id=body.message_id,
+                swarm_id=body.swarm_id,
+                sender_id=body.sender.agent_id,
+                recipient_id=body.recipient,
+                message_type=body.type,
+                content=toon_content,
+                received_at=datetime.now(timezone.utc),
+                status=InboxStatus.UNREAD,
+            )
             repo = InboxRepository(conn)
             try:
                 await repo.insert(inbox_msg)
             except sqlite3.IntegrityError:
+                existing = await repo.get_by_id(body.message_id)
+                if existing is None:
+                    raise
                 logger.debug(
                     "Duplicate message %s ignored (idempotent)",
                     body.message_id,
+                )
+                return MessageQueuedResponse(
+                    status="queued",
+                    message_id=body.message_id,
                 )
 
         # Receiver-side membership lifecycle dispatch (issue #197). Fire
@@ -73,14 +119,17 @@ def create_message_router(db: DatabaseManager, local_agent_id: str) -> APIRouter
         except Exception as exc:
             logger.warning(
                 "System dispatch failed for message %s: %s",
-                body.message_id, exc,
+                body.message_id,
+                exc,
             )
 
         # Fire-and-forget wake trigger evaluation (non-blocking).
         # Catch all exceptions: wake is a side effect that must never
         # prevent message acceptance (e.g. httpx.ReadTimeout, WakeTriggerError).
         wake_trigger: Optional[WakeTrigger] = getattr(
-            request.app.state, "wake_trigger", None,
+            request.app.state,
+            "wake_trigger",
+            None,
         )
         if wake_trigger is not None:
             try:
@@ -99,7 +148,8 @@ def create_message_router(db: DatabaseManager, local_agent_id: str) -> APIRouter
                 )
 
         return MessageQueuedResponse(
-            status="queued", message_id=body.message_id,
+            status="queued",
+            message_id=body.message_id,
         )
 
     return router

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,14 +1,19 @@
 """Pytest fixtures for server tests."""
 import base64
 import json
-import pytest
 from pathlib import Path
-from tempfile import TemporaryDirectory
+
+import pytest
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
 from fastapi.testclient import TestClient
+
 from src.server.app import create_app
 from src.server.config import (
-    ServerConfig, AgentConfig, RateLimitConfig, WakeConfig, WakeEndpointConfig,
+    AgentConfig,
+    RateLimitConfig,
+    ServerConfig,
+    WakeConfig,
+    WakeEndpointConfig,
 )
 
 
@@ -51,6 +56,23 @@ def client(server_config: ServerConfig) -> TestClient:
     app = create_app(server_config)
     with TestClient(app) as c:
         yield c
+
+
+@pytest.fixture
+def bypass_message_auth(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Isolate existing route-behavior tests from message authentication.
+
+    Cryptographic authentication is exercised end-to-end in
+    ``test_message_auth.py``. Persistence, dispatch, wake, and rate-limit tests
+    use this fixture so their setup remains focused on the behavior under test.
+    """
+    async def _allow_message(*args, **kwargs) -> None:
+        return None
+
+    monkeypatch.setattr(
+        "src.server.routes.message.authenticate_message",
+        _allow_message,
+    )
 
 
 @pytest.fixture

--- a/tests/test_inbox_api.py
+++ b/tests/test_inbox_api.py
@@ -15,9 +15,11 @@ from src.server.app import create_app
 from src.server.config import AgentConfig, ServerConfig, WakeConfig, WakeEndpointConfig
 from src.state.database import DatabaseManager
 from src.state.models.inbox import InboxMessage, InboxStatus
-from src.state.models.outbox import OutboxMessage, OutboxStatus
+from src.state.models.outbox import OutboxMessage
 from src.state.repositories.inbox import InboxRepository
 from src.state.repositories.outbox import OutboxRepository
+
+pytestmark = pytest.mark.usefixtures("bypass_message_auth")
 
 SWARM_ID = "716a4150-ab9d-4b54-a2a8-f2b7c607c21e"
 MSG_1 = "aaa00000-0000-0000-0000-000000000001"

--- a/tests/test_message_auth.py
+++ b/tests/test_message_auth.py
@@ -1,0 +1,319 @@
+"""End-to-end authentication tests for inbound swarm messages."""
+
+import asyncio
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import UUID
+
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from fastapi.testclient import TestClient
+
+from src.client.crypto import public_key_to_base64, sign_message
+from src.server.app import create_app
+from src.server.config import (
+    AgentConfig,
+    RateLimitConfig,
+    ServerConfig,
+    WakeConfig,
+    WakeEndpointConfig,
+)
+from src.state.database import DatabaseManager
+from src.state.models.member import SwarmMember, SwarmMembership
+from src.state.repositories.inbox import InboxRepository
+from src.state.repositories.membership import MembershipRepository
+
+LOCAL_AGENT_ID = "receiver-agent"
+SENDER_AGENT_ID = "sender-agent"
+SENDER_ENDPOINT = "https://sender.example.com/swarm"
+SWARM_ID = "660e8400-e29b-41d4-a716-446655440001"
+MESSAGE_ID = "550e8400-e29b-41d4-a716-446655440000"
+TIMESTAMP = "2026-02-05T14:30:00.000Z"
+
+
+def _config(db_path: Path) -> ServerConfig:
+    return ServerConfig(
+        agent=AgentConfig(
+            agent_id=LOCAL_AGENT_ID,
+            endpoint="https://receiver.example.com",
+            public_key="not-used-for-inbound-verification",
+            protocol_version="0.1.0",
+        ),
+        rate_limit=RateLimitConfig(messages_per_minute=100),
+        db_path=db_path,
+        wake=WakeConfig(enabled=False, endpoint=""),
+        wake_endpoint=WakeEndpointConfig(enabled=False),
+    )
+
+
+def _seed_sender(
+    db_path: Path,
+    private_key: Ed25519PrivateKey,
+    *,
+    endpoint: str = SENDER_ENDPOINT,
+    public_key: str | None = None,
+) -> None:
+    async def _seed() -> None:
+        db = DatabaseManager(db_path)
+        await db.initialize()
+        member = SwarmMember(
+            agent_id=SENDER_AGENT_ID,
+            endpoint=endpoint,
+            public_key=public_key
+            or public_key_to_base64(private_key.public_key()),
+            joined_at=datetime.now(timezone.utc),
+        )
+        membership = SwarmMembership(
+            swarm_id=SWARM_ID,
+            name="Authentication Test Swarm",
+            master=SENDER_AGENT_ID,
+            members=(member,),
+            joined_at=datetime.now(timezone.utc),
+        )
+        async with db.connection() as conn:
+            await MembershipRepository(conn).create_swarm(membership)
+        await db.close()
+
+    asyncio.run(_seed())
+
+
+def _signed_message(
+    private_key: Ed25519PrivateKey,
+    *,
+    recipient: str = LOCAL_AGENT_ID,
+    endpoint: str = SENDER_ENDPOINT,
+    content: str = "authenticated test message",
+    timestamp: str = TIMESTAMP,
+) -> dict:
+    parsed_timestamp = datetime.fromisoformat(timestamp.replace("Z", "+00:00"))
+    signature = sign_message(
+        private_key,
+        UUID(MESSAGE_ID),
+        parsed_timestamp,
+        UUID(SWARM_ID),
+        recipient,
+        "message",
+        content,
+    )
+    return {
+        "protocol_version": "0.1.0",
+        "message_id": MESSAGE_ID,
+        "timestamp": timestamp,
+        "sender": {
+            "agent_id": SENDER_AGENT_ID,
+            "endpoint": endpoint,
+        },
+        "recipient": recipient,
+        "swarm_id": SWARM_ID,
+        "type": "message",
+        "content": content,
+        "signature": signature,
+    }
+
+
+def _headers(
+    *,
+    sender: str = SENDER_AGENT_ID,
+    protocol: str = "0.1.0",
+) -> dict[str, str]:
+    return {
+        "Content-Type": "application/json",
+        "X-Agent-ID": sender,
+        "X-Swarm-Protocol": protocol,
+    }
+
+
+def _post(db_path: Path, message: dict, headers: dict[str, str]):
+    with TestClient(create_app(_config(db_path))) as client:
+        return client.post("/swarm/message", json=message, headers=headers)
+
+
+def test_accepts_registered_sender_with_valid_signature(tmp_path: Path) -> None:
+    key = Ed25519PrivateKey.generate()
+    db_path = tmp_path / "valid.db"
+    _seed_sender(db_path, key)
+
+    response = _post(db_path, _signed_message(key), _headers())
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "queued", "message_id": MESSAGE_ID}
+
+
+def test_rejects_sender_header_mismatch(tmp_path: Path) -> None:
+    key = Ed25519PrivateKey.generate()
+    db_path = tmp_path / "sender-header.db"
+    _seed_sender(db_path, key)
+
+    response = _post(
+        db_path,
+        _signed_message(key),
+        _headers(sender="different-agent"),
+    )
+
+    assert response.status_code == 403
+    assert response.json()["error"]["code"] == "NOT_AUTHORIZED"
+
+
+def test_rejects_protocol_header_mismatch(tmp_path: Path) -> None:
+    key = Ed25519PrivateKey.generate()
+    db_path = tmp_path / "protocol-header.db"
+    _seed_sender(db_path, key)
+
+    response = _post(
+        db_path,
+        _signed_message(key),
+        _headers(protocol="9.9.9"),
+    )
+
+    assert response.status_code == 403
+    assert response.json()["error"]["code"] == "NOT_AUTHORIZED"
+
+
+def test_rejects_unknown_swarm(tmp_path: Path) -> None:
+    key = Ed25519PrivateKey.generate()
+    db_path = tmp_path / "unknown-swarm.db"
+
+    response = _post(db_path, _signed_message(key), _headers())
+
+    assert response.status_code == 404
+    assert response.json()["error"]["code"] == "SWARM_NOT_FOUND"
+
+
+def test_rejects_unregistered_sender(tmp_path: Path) -> None:
+    registered_key = Ed25519PrivateKey.generate()
+    unregistered_key = Ed25519PrivateKey.generate()
+    db_path = tmp_path / "unregistered.db"
+    _seed_sender(db_path, registered_key)
+    message = _signed_message(unregistered_key)
+    message["sender"]["agent_id"] = "unregistered-agent"
+
+    response = _post(
+        db_path,
+        message,
+        _headers(sender="unregistered-agent"),
+    )
+
+    assert response.status_code == 403
+    assert response.json()["error"]["code"] == "NOT_AUTHORIZED"
+
+
+def test_rejects_sender_endpoint_mismatch(tmp_path: Path) -> None:
+    key = Ed25519PrivateKey.generate()
+    db_path = tmp_path / "endpoint.db"
+    _seed_sender(db_path, key)
+
+    response = _post(
+        db_path,
+        _signed_message(key, endpoint="https://other.example.com/swarm"),
+        _headers(),
+    )
+
+    assert response.status_code == 403
+    assert response.json()["error"]["code"] == "NOT_AUTHORIZED"
+
+
+def test_rejects_message_for_another_recipient(tmp_path: Path) -> None:
+    key = Ed25519PrivateKey.generate()
+    db_path = tmp_path / "recipient.db"
+    _seed_sender(db_path, key)
+
+    response = _post(
+        db_path,
+        _signed_message(key, recipient="another-agent"),
+        _headers(),
+    )
+
+    assert response.status_code == 403
+    assert response.json()["error"]["code"] == "NOT_AUTHORIZED"
+
+
+def test_accepts_signed_broadcast(tmp_path: Path) -> None:
+    key = Ed25519PrivateKey.generate()
+    db_path = tmp_path / "broadcast.db"
+    _seed_sender(db_path, key)
+
+    response = _post(
+        db_path,
+        _signed_message(key, recipient="broadcast"),
+        _headers(),
+    )
+
+    assert response.status_code == 200
+
+
+def test_rejects_tampered_content_without_persisting(tmp_path: Path) -> None:
+    key = Ed25519PrivateKey.generate()
+    db_path = tmp_path / "tampered.db"
+    _seed_sender(db_path, key)
+    message = _signed_message(key)
+    message["content"] = "tampered after signing"
+
+    response = _post(db_path, message, _headers())
+
+    assert response.status_code == 401
+    assert response.json()["error"]["code"] == "INVALID_SIGNATURE"
+
+    async def _verify_absent() -> None:
+        db = DatabaseManager(db_path)
+        await db.initialize()
+        async with db.connection() as conn:
+            stored = await InboxRepository(conn).get_by_id(MESSAGE_ID)
+        await db.close()
+        assert stored is None
+
+    asyncio.run(_verify_absent())
+
+
+def test_rejects_invalid_registered_public_key(tmp_path: Path) -> None:
+    key = Ed25519PrivateKey.generate()
+    db_path = tmp_path / "invalid-public-key.db"
+    _seed_sender(db_path, key, public_key="invalid-public-key")
+
+    response = _post(db_path, _signed_message(key), _headers())
+
+    assert response.status_code == 500
+    assert response.json()["error"]["code"] == "INTERNAL_ERROR"
+
+
+def test_rejects_timestamp_without_timezone(tmp_path: Path) -> None:
+    key = Ed25519PrivateKey.generate()
+    db_path = tmp_path / "timestamp.db"
+    _seed_sender(db_path, key)
+    message = _signed_message(key)
+    message["timestamp"] = "2026-02-05T14:30:00.000"
+
+    response = _post(db_path, message, _headers())
+
+    assert response.status_code == 400
+    assert response.json()["error"]["code"] == "INVALID_FORMAT"
+
+
+def test_duplicate_does_not_repeat_dispatch_or_wake(tmp_path: Path) -> None:
+    key = Ed25519PrivateKey.generate()
+    db_path = tmp_path / "duplicate.db"
+    _seed_sender(db_path, key)
+    app = create_app(_config(db_path))
+    wake_trigger = MagicMock()
+    wake_trigger.process_message = AsyncMock()
+
+    with patch(
+        "src.server.routes.message.dispatch_system_message",
+        new_callable=AsyncMock,
+    ) as dispatch:
+        with TestClient(app) as client:
+            app.state.wake_trigger = wake_trigger
+            first = client.post(
+                "/swarm/message",
+                json=_signed_message(key),
+                headers=_headers(),
+            )
+            second = client.post(
+                "/swarm/message",
+                json=_signed_message(key),
+                headers=_headers(),
+            )
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+    dispatch.assert_awaited_once()
+    wake_trigger.process_message.assert_awaited_once()

--- a/tests/test_message_persistence.py
+++ b/tests/test_message_persistence.py
@@ -2,16 +2,23 @@
 import asyncio
 from pathlib import Path
 
+import pytest
 import toon
 from fastapi.testclient import TestClient
 
 from src.server.app import create_app
 from src.server.config import (
-    AgentConfig, RateLimitConfig, ServerConfig, WakeConfig, WakeEndpointConfig,
+    AgentConfig,
+    RateLimitConfig,
+    ServerConfig,
+    WakeConfig,
+    WakeEndpointConfig,
 )
 from src.state.database import DatabaseManager
 from src.state.models.inbox import InboxStatus
 from src.state.repositories.inbox import InboxRepository
+
+pytestmark = pytest.mark.usefixtures("bypass_message_auth")
 
 
 def _make_config(tmp_path: Path) -> ServerConfig:

--- a/tests/test_receiver_member_sync.py
+++ b/tests/test_receiver_member_sync.py
@@ -17,6 +17,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
 from fastapi.testclient import TestClient
 
 from src.server.app import create_app
@@ -32,6 +33,8 @@ from src.state.models.member import SwarmMember, SwarmMembership, SwarmSettings
 from src.state.models.public_key import PublicKeyEntry
 from src.state.repositories.keys import PublicKeyRepository
 from src.state.repositories.membership import MembershipRepository
+
+pytestmark = pytest.mark.usefixtures("bypass_message_auth")
 
 SWARM_ID = "550e8400-e29b-41d4-a716-446655440000"
 LOCAL_AGENT_ID = "test-agent-001"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,22 +1,27 @@
 """Tests for the FastAPI server."""
 import asyncio
 import base64
-import json
-
 from datetime import datetime, timezone
 from pathlib import Path
 
+import pytest
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
 from fastapi.testclient import TestClient
 
 from src.server.app import create_app
 from src.server.config import (
-    ServerConfig, AgentConfig, RateLimitConfig, WakeConfig, WakeEndpointConfig,
+    AgentConfig,
+    RateLimitConfig,
+    ServerConfig,
+    WakeConfig,
+    WakeEndpointConfig,
 )
 from src.state.database import DatabaseManager
 from src.state.models.member import SwarmMember, SwarmMembership, SwarmSettings
 from src.state.repositories.membership import MembershipRepository
-from tests.conftest import _b64url_encode, _make_jwt
+from tests.conftest import _make_jwt
+
+pytestmark = pytest.mark.usefixtures("bypass_message_auth")
 
 
 SWARM_ID = "550e8400-e29b-41d4-a716-446655440000"

--- a/tests/test_wake_trigger_wiring.py
+++ b/tests/test_wake_trigger_wiring.py
@@ -1,20 +1,25 @@
 """Integration tests: WakeTrigger is called after message persistence."""
 import asyncio
-import json
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from fastapi.testclient import TestClient
 
+from src.claude.wake_trigger import WakeTrigger
 from src.server.app import create_app
 from src.server.config import (
-    AgentConfig, RateLimitConfig, ServerConfig, WakeConfig, WakeEndpointConfig,
+    AgentConfig,
+    RateLimitConfig,
+    ServerConfig,
+    WakeConfig,
+    WakeEndpointConfig,
     _parse_bool,
 )
-from src.claude.wake_trigger import WakeDecision, WakeTrigger
 from src.state.database import DatabaseManager
 from src.state.repositories.inbox import InboxRepository
+
+pytestmark = pytest.mark.usefixtures("bypass_message_auth")
 
 
 def _make_config(tmp_path: Path, wake_enabled: bool = False) -> ServerConfig:


### PR DESCRIPTION
## Summary

- authenticate every inbound `/swarm/message` request before persistence
- require transport headers to match the message envelope
- authorize the sender against the referenced swarm membership and registered endpoint
- verify the Ed25519 signature with the member's registered public key
- reject messages for another recipient and preserve signed broadcasts
- treat only an existing inbox row as an idempotent duplicate, and do not repeat dispatch or wake side effects on replay

## Security behavior

Authentication failures return the protocol's structured error codes without logging message content or signatures. Rejected messages are not persisted.

## Validation

- `ruff check` passed on the changed surface
- `pytest -q --tb=short`: 569 passed
- end-to-end coverage includes valid signatures, broadcasts, forged/tampered content, unknown swarms, non-members, endpoint/header/recipient mismatches, malformed registered keys, and duplicate side effects
